### PR TITLE
feat(analyze_selection): learnset フィルタを適用する

### DIFF
--- a/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
+++ b/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { Generations, toID } from "@smogon/calc";
 import { DamageCalculatorAdapter } from "@ai-rotom/shared";
 import type { DamageCalcResult } from "@ai-rotom/shared";
-import { pokemonEntryProvider } from "../../data-store";
+import {
+  championsLearnsets,
+  pokemonEntryProvider,
+  toDataId,
+} from "../../data-store";
 import {
   pokemonNameResolver,
   moveNameResolver,
@@ -10,7 +14,12 @@ import {
   itemNameResolver,
   natureNameResolver,
 } from "../../name-resolvers";
-import { bestDamageEstimate } from "./selection-analysis";
+import {
+  bestDamageEstimate,
+  calculateDamageForMatchup,
+  filterResultsByLearnset,
+  getLearnsetMoveIdSet,
+} from "./selection-analysis";
 
 const CHAMPIONS_GEN_NUM = 0;
 
@@ -176,11 +185,157 @@ describe("analyze_selection logic", () => {
         }),
       ];
       const out = bestDamageEstimate(results, () => undefined);
-      // 先頭技が採用され、2 件目が採用されないことを固定する。
-      // 実装が results[results.length - 1] 等に変わると失敗する。
       expect(out?.move.name).toBe("HighDamageMove");
       expect(out?.max).toBe(HIGH_MAX);
       expect(out?.min).toBe(HIGH_MIN);
+    });
+
+  });
+
+  describe("getLearnsetMoveIdSet", () => {
+    it("登録済みポケモン (Charizard) は learnset の技 ID を返す", () => {
+      const ids = getLearnsetMoveIdSet(toDataId("Charizard"));
+      expect(ids.size).toBeGreaterThan(0);
+      expect(ids.has("flamethrower")).toBe(true);
+    });
+
+    it("未登録ポケモン ID は空 Set を返す (フォールバック挙動)", () => {
+      const ids = getLearnsetMoveIdSet("nonexistentpokemon");
+      expect(ids.size).toBe(0);
+    });
+  });
+
+  describe("filterResultsByLearnset", () => {
+    const BASE_MIN_PERCENT = 50;
+    const BASE_MAX_PERCENT = 80;
+    const BASE_MIN_DAMAGE = 60;
+    const BASE_MAX_DAMAGE = 90;
+
+    function makeMoveResult(moveName: string): DamageCalcResult {
+      return {
+        attacker: "Charizard",
+        defender: "Garchomp",
+        move: moveName,
+        damage: [BASE_MIN_DAMAGE, BASE_MAX_DAMAGE],
+        min: BASE_MIN_DAMAGE,
+        max: BASE_MAX_DAMAGE,
+        minPercent: BASE_MIN_PERCENT,
+        maxPercent: BASE_MAX_PERCENT,
+        koChance: "test",
+        description: "test",
+      };
+    }
+
+    it("learnset に含まれる技のみを残す", () => {
+      const results = [
+        makeMoveResult("Flamethrower"),
+        makeMoveResult("Blizzard"),
+        makeMoveResult("Splash"),
+      ];
+      const learnsetIds = new Set(["flamethrower"]);
+      const filtered = filterResultsByLearnset(results, learnsetIds);
+      expect(filtered.map((r) => r.move)).toEqual(["Flamethrower"]);
+    });
+
+    it("learnset が空のときは元の配列をそのまま返す (フォールバック)", () => {
+      const results = [
+        makeMoveResult("Flamethrower"),
+        makeMoveResult("Blizzard"),
+      ];
+      const filtered = filterResultsByLearnset(results, new Set());
+      expect(filtered.map((r) => r.move)).toEqual(["Flamethrower", "Blizzard"]);
+    });
+
+    it("technique 名の大小 / 空白等は toDataId で正規化して一致判定する", () => {
+      const results = [makeMoveResult("Acid Spray")];
+      const learnsetIds = new Set(["acidspray"]);
+      const filtered = filterResultsByLearnset(results, learnsetIds);
+      expect(filtered.length).toBe(1);
+    });
+  });
+
+  describe("calculateDamageForMatchup - learnset filter integration", () => {
+    it("movesMap 未指定時は attacker が覚えない技を候補から除外する", () => {
+      const attackerId = toDataId("Charizard");
+      const learnsetIds = getLearnsetMoveIdSet(attackerId);
+
+      // 前提: charizard の learnset は登録済みで、blizzard / splash 等は含まれない
+      expect(learnsetIds.size).toBeGreaterThan(0);
+      expect(learnsetIds.has("blizzard")).toBe(false);
+      expect(learnsetIds.has("splash")).toBe(false);
+
+      const results = calculateDamageForMatchup(
+        adapter,
+        { name: "リザードン" },
+        { name: "ギャラドス" },
+        attackerId,
+        learnsetIds,
+        new Map(),
+      );
+
+      expect(results.length).toBeGreaterThan(0);
+      for (const r of results) {
+        expect(learnsetIds.has(toDataId(r.move))).toBe(true);
+      }
+    });
+
+    it("movesMap 明示指定時は learnset 外の技もフィルタされず計算される (既存仕様維持)", () => {
+      const attackerId = toDataId("Charizard");
+      const learnsetIds = getLearnsetMoveIdSet(attackerId);
+
+      // 「ふぶき」(Blizzard) は charizard の learnset に含まれない想定を念押し
+      expect(learnsetIds.has("blizzard")).toBe(false);
+
+      const movesMap = new Map<string, string[]>([[attackerId, ["Blizzard"]]]);
+
+      const results = calculateDamageForMatchup(
+        adapter,
+        { name: "リザードン" },
+        { name: "ギャラドス" },
+        attackerId,
+        learnsetIds,
+        movesMap,
+      );
+
+      expect(results.length).toBe(1);
+      expect(results[0].move).toBe("Blizzard");
+    });
+
+    it("learnset 未登録ポケモンは全技を通す (フォールバック挙動)", () => {
+      const attackerId = toDataId("Charizard");
+      const results = calculateDamageForMatchup(
+        adapter,
+        { name: "リザードン" },
+        { name: "ギャラドス" },
+        attackerId,
+        new Set(), // learnset 未登録相当
+        new Map(),
+      );
+      // フォールバックで空 Set の場合、@smogon/calc の calculateAllMoves 結果をそのまま返す
+      // learnset 登録済みの charizard で実際に絞った結果より件数が多いことを確認
+      const filteredResults = calculateDamageForMatchup(
+        adapter,
+        { name: "リザードン" },
+        { name: "ギャラドス" },
+        attackerId,
+        getLearnsetMoveIdSet(attackerId),
+        new Map(),
+      );
+      expect(results.length).toBeGreaterThan(filteredResults.length);
+    });
+  });
+
+  describe("learnset データ前提確認", () => {
+    // 下流テストの前提 (charizard が覚える/覚えない技) を固定する
+    it("charizard の learnset に flamethrower が含まれる", () => {
+      expect(championsLearnsets["charizard"]).toBeDefined();
+      expect(championsLearnsets["charizard"]).toContain("flamethrower");
+    });
+
+    it("charizard の learnset に blizzard / splash は含まれない", () => {
+      const moves = championsLearnsets["charizard"] ?? [];
+      expect(moves).not.toContain("blizzard");
+      expect(moves).not.toContain("splash");
     });
   });
 });

--- a/packages/mcp-server/src/tools/analysis/selection-analysis.ts
+++ b/packages/mcp-server/src/tools/analysis/selection-analysis.ts
@@ -12,6 +12,7 @@ import {
   type SpeedComparison,
 } from "@ai-rotom/shared";
 import {
+  championsLearnsets,
   pokemonById,
   pokemonEntryProvider,
   toDataId,
@@ -241,14 +242,44 @@ function resolveMovesMap(
 }
 
 /**
+ * 指定ポケモンの learnset に含まれる技 ID セットを取得する。
+ * 未登録のポケモンは空 Set を返す。
+ * TODO(#13): shared 昇格後は @ai-rotom/shared の共通実装に差し替える。
+ */
+export function getLearnsetMoveIdSet(
+  pokemonId: string,
+): ReadonlySet<string> {
+  const learnset = championsLearnsets[pokemonId];
+  if (learnset === undefined) return new Set();
+  return new Set(learnset);
+}
+
+/**
+ * calculateAllMoves の結果を attacker の learnset で絞り込む。
+ * @smogon/calc は全技を走査するため、実際に覚えない技で過大評価しないようにフィルタする。
+ * learnsetMoveIds が空 (= learnset 未登録) の場合はフォールバックで元の配列をそのまま返す。
+ * TODO(#13): shared 昇格後は @ai-rotom/shared の共通実装に差し替える。
+ */
+export function filterResultsByLearnset(
+  results: readonly DamageCalcResult[],
+  learnsetMoveIds: ReadonlySet<string>,
+): DamageCalcResult[] {
+  if (learnsetMoveIds.size === 0) return [...results];
+  return results.filter((r) => learnsetMoveIds.has(toDataId(r.move)));
+}
+
+/**
  * attacker vs defender の候補技でダメージを計算する。
  * movesMap に指定があればそれを、無ければ全技で計算する。
+ * movesMap 未指定経路では attacker の learnset でフィルタし、覚えない技での過大評価を避ける。
+ * 明示指定経路は learnset フィルタを掛けない（ユーザーの明示選択を尊重する既存仕様を維持）。
  */
-function calculateDamageForMatchup(
+export function calculateDamageForMatchup(
   calculator: DamageCalculatorAdapter,
   attacker: PokemonInput,
   defender: PokemonInput,
   attackerId: string,
+  attackerLearnsetIds: ReadonlySet<string>,
   movesMap: Map<string, string[]>,
 ): DamageCalcResult[] {
   const explicitMoves = movesMap.get(attackerId);
@@ -270,7 +301,8 @@ function calculateDamageForMatchup(
     results.sort((a, b) => b.max - a.max);
     return results;
   }
-  return calculator.calculateAllMoves({ attacker, defender });
+  const allResults = calculator.calculateAllMoves({ attacker, defender });
+  return filterResultsByLearnset(allResults, attackerLearnsetIds);
 }
 
 export function registerSelectionAnalysisTool(server: McpServer): void {
@@ -333,6 +365,12 @@ export function registerSelectionAnalysisTool(server: McpServer): void {
       const myMembers = args.myParty.map(buildMemberContext);
       const oppMembers = args.opponentParty.map(buildMemberContext);
 
+      // 各自軍ポケモンの learnset ID セットは対面ごとに変わらないため、外側ループで 1 回だけ引く
+      const myLearnsetIds = new Map<string, ReadonlySet<string>>();
+      for (const mine of myMembers) {
+        myLearnsetIds.set(mine.entryId, getLearnsetMoveIdSet(mine.entryId));
+      }
+
       // マトリクス作成
       const matrix: MatchupEntry[] = [];
 
@@ -361,6 +399,7 @@ export function registerSelectionAnalysisTool(server: McpServer): void {
               mine.input,
               opp.input,
               mine.entryId,
+              myLearnsetIds.get(mine.entryId) ?? new Set(),
               movesMap,
             );
             damageEstimate = bestDamageEstimate(


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/ai-rotom/issues/17

`analyze_selection` の `calculateDamageForMatchup` は `moves` 未指定時に `calculator.calculateAllMoves` の結果をそのまま返しており、attacker が実際には覚えない技（例: リザードンの「ふぶき」）が `DamageEstimate.move` に採用される可能性があった。`find-counters` と同等の learnset フィルタをかけて選出推奨の精度を改善する。

#13 で shared 昇格を予定しているため、暫定ローカル実装に `TODO(#13)` を明記した。

## Changes

* `packages/mcp-server/src/tools/analysis/selection-analysis.ts`
  * `getLearnsetMoveIdSet` / `filterResultsByLearnset` を追加（`find-counters` と同ロジック。#13 で shared 昇格予定）
  * `calculateDamageForMatchup` のシグネチャに `attackerLearnsetIds: ReadonlySet<string>` を追加し、`movesMap` 未指定経路で `calculateAllMoves` 結果を learnset で絞り込む
  * 明示技指定経路はフィルタ非適用（ユーザーの明示選択を尊重する既存仕様を維持）
  * 自軍パーティの learnset ID セットを外側ループで 1 回だけ計算してマップ化（`championsLearnsets` ルックアップを 36 → 6 に削減）
  * テスタビリティのため `calculateDamageForMatchup` / ヘルパー群を `export`
* `packages/mcp-server/src/tools/analysis/selection-analysis.test.ts`
  * `getLearnsetMoveIdSet` の登録済み / 未登録ケース
  * `filterResultsByLearnset` の通常 / 空 Set フォールバック / `toDataId` 正規化
  * `calculateDamageForMatchup` 結合テスト: learnset フィルタ適用 / 明示技優先 / 未登録ポケモンのフォールバック
  * 下流テストの前提となる learnset データ (charizard) 検証

## Checklist

- [x] 既存テスト維持（`npm test` で 27 files / 289 tests 全 pass）
- [x] 追加テストで learnset フィルタ挙動を検証（learnset 内技のみ残る / 明示技は素通り / 未登録はフォールバック）
- [x] `npm run build` が通ること
- [x] `tsc --noEmit` が通ること
- [x] 明示技指定時の既存仕様（learnset 外技も計算対象）を壊していない

## その他

- 本 PR は #13 (filterResultsByLearnset の shared 昇格) 未完了前提で、暫定的に mcp-server 側にローカル実装を置いている
- #13 マージ後のフォロー PR で `@ai-rotom/shared` 経由の import に差し替える予定（`TODO(#13)` コメントを目印）

🤖 Generated with [Claude Code](https://claude.com/claude-code)