### PR TITLE
feat(shared): conditions.battleFormat でダブルバトル対戦に対応

### DIFF
--- a/packages/mcp-server/src/tools/analysis/find-counters.ts
+++ b/packages/mcp-server/src/tools/analysis/find-counters.ts
@@ -10,6 +10,7 @@ import {
   pokemonSchema,
   type BaseStats,
   type BoostsInput,
+  type ConditionsInput,
   type DamageCalcResult,
   type EvsInput,
   type PokemonEntry,
@@ -456,6 +457,12 @@ export function registerFindCountersTool(server: McpServer): void {
     try {
       const gen = Generations.get(CHAMPIONS_GEN_NUM);
 
+      // battleFormat (トップレベル入力) を conditions に詰め直し、ダメ計に伝える。
+      // ダブル時は @smogon/calc が全体攻撃技の威力 ×0.75 等のダブル補正を適用する。
+      const damageConditions: ConditionsInput = {
+        battleFormat: args.battleFormat,
+      };
+
       // target を解決
       const targetEntry = resolvePokemonEntry(args.target.name);
       const { pokemon: targetObj, resolvedName: targetName }
@@ -506,6 +513,7 @@ export function registerFindCountersTool(server: McpServer): void {
           const allOutgoing = calculator.calculateAllMoves({
             attacker: candidateInput,
             defender: args.target,
+            conditions: damageConditions,
           });
           const candidateLearnsetIds = getLearnsetMoveIdSet(candidateEntry.id);
           outgoing = filterResultsByLearnset(
@@ -520,6 +528,7 @@ export function registerFindCountersTool(server: McpServer): void {
           const allIncoming = calculator.calculateAllMoves({
             attacker: args.target,
             defender: candidateInput,
+            conditions: damageConditions,
           });
           const targetLearnsetIds = getLearnsetMoveIdSet(targetEntry.id);
           incoming = filterResultsByLearnset(

--- a/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
+++ b/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
@@ -386,4 +386,81 @@ describe("analyze_selection logic", () => {
     });
   });
 
+  describe("battleFormat による AoE 技のダメージ補正", () => {
+    // 全体攻撃技 (target: allAdjacent / allAdjacentFoes) は doubles で威力 ×0.75 になる。
+    // @smogon/calc Gen 0 champions mechanics が自動適用する想定。
+    const AOE_DOUBLES_MULTIPLIER = 3072 / 4096;
+    const TOLERANCE = 0.06;
+
+    it("じしん (allAdjacent) はダブル指定時にシングル比でおおむね 0.75 倍になる", () => {
+      // 防御側は Ground 無効を持たないポケモン (カビゴンは Normal 単タイプ)。
+      const attacker = { name: "ガブリアス" };
+      const defender = { name: "カビゴン" };
+
+      const singlesResult = adapter.calculate({
+        attacker,
+        defender,
+        moveName: "じしん",
+        conditions: { battleFormat: "singles" },
+      });
+
+      const doublesResult = adapter.calculate({
+        attacker,
+        defender,
+        moveName: "じしん",
+        conditions: { battleFormat: "doubles" },
+      });
+
+      expect(singlesResult.max).toBeGreaterThan(0);
+      expect(doublesResult.max).toBeGreaterThan(0);
+
+      const ratio = doublesResult.max / singlesResult.max;
+      expect(ratio).toBeGreaterThan(AOE_DOUBLES_MULTIPLIER - TOLERANCE);
+      expect(ratio).toBeLessThan(AOE_DOUBLES_MULTIPLIER + TOLERANCE);
+    });
+
+    it("単体技 (れいとうビーム) はダブル指定でもダメージが変わらない", () => {
+      const attacker = { name: "リザードン" };
+      const defender = { name: "ガブリアス" };
+
+      const singlesResult = adapter.calculate({
+        attacker,
+        defender,
+        moveName: "れいとうビーム",
+        conditions: { battleFormat: "singles" },
+      });
+
+      const doublesResult = adapter.calculate({
+        attacker,
+        defender,
+        moveName: "れいとうビーム",
+        conditions: { battleFormat: "doubles" },
+      });
+
+      expect(singlesResult.max).toBe(doublesResult.max);
+      expect(singlesResult.min).toBe(doublesResult.min);
+    });
+
+    it("conditions 省略時は singles 扱い (既存挙動と同じ)", () => {
+      // 防御側は Ground 無効を持たないポケモン (カビゴンは Normal 単タイプ)。
+      const attacker = { name: "ガブリアス" };
+      const defender = { name: "カビゴン" };
+
+      const noConditionsResult = adapter.calculate({
+        attacker,
+        defender,
+        moveName: "じしん",
+      });
+
+      const singlesResult = adapter.calculate({
+        attacker,
+        defender,
+        moveName: "じしん",
+        conditions: { battleFormat: "singles" },
+      });
+
+      expect(noConditionsResult.max).toBe(singlesResult.max);
+      expect(noConditionsResult.min).toBe(singlesResult.min);
+    });
+  });
 });

--- a/packages/mcp-server/src/tools/analysis/selection-analysis.ts
+++ b/packages/mcp-server/src/tools/analysis/selection-analysis.ts
@@ -10,6 +10,7 @@ import {
   filterResultsByLearnset,
   pokemonSchema,
   type BaseStats,
+  type ConditionsInput,
   type DamageCalcResult,
   type PriorityMoveInfo,
   type SpeedComparison,
@@ -184,6 +185,7 @@ function resolveMovesMap(
  * movesMap に指定があればそれを、無ければ全技で計算する。
  * movesMap 未指定経路では attacker の learnset でフィルタし、覚えない技での過大評価を避ける。
  * 明示指定経路は learnset フィルタを掛けない（ユーザーの明示選択を尊重する既存仕様を維持）。
+ * conditions (battleFormat 等) を calculator に伝える。
  */
 export function calculateDamageForMatchup(
   calculator: DamageCalculatorAdapter,
@@ -192,6 +194,7 @@ export function calculateDamageForMatchup(
   attackerId: string,
   attackerLearnsetIds: ReadonlySet<string>,
   movesMap: Map<string, string[]>,
+  conditions?: ConditionsInput,
 ): DamageCalcResult[] {
   const explicitMoves = movesMap.get(attackerId);
   if (explicitMoves !== undefined && explicitMoves.length > 0) {
@@ -203,6 +206,7 @@ export function calculateDamageForMatchup(
             attacker,
             defender,
             moveName,
+            conditions,
           }),
         );
       } catch {
@@ -212,7 +216,7 @@ export function calculateDamageForMatchup(
     results.sort((a, b) => b.max - a.max);
     return results;
   }
-  const allResults = calculator.calculateAllMoves({ attacker, defender });
+  const allResults = calculator.calculateAllMoves({ attacker, defender, conditions });
   return filterResultsByLearnset(allResults, attackerLearnsetIds, toDataId);
 }
 
@@ -232,6 +236,12 @@ export function registerSelectionAnalysisTool(server: McpServer): void {
     try {
       const gen = Generations.get(CHAMPIONS_GEN_NUM);
       const movesMap = resolveMovesMap(args.moves);
+
+      // battleFormat (トップレベル) を conditions に詰め直してダメ計に伝える。
+      // これがないと @smogon/calc 側でダブル補正 (AoE 技 ×0.75 等) が効かない。
+      const damageConditions: ConditionsInput = {
+        battleFormat: args.battleFormat,
+      };
 
       // プロフィール作成
       interface PartyMemberContext {
@@ -320,6 +330,7 @@ export function registerSelectionAnalysisTool(server: McpServer): void {
               mine.entryId,
               myLearnsetIds.get(mine.entryId) ?? new Set(),
               movesMap,
+              damageConditions,
             );
             damageEstimate = bestDamageEstimate(
               results,

--- a/shared/src/calc/builders/field-builder.test.ts
+++ b/shared/src/calc/builders/field-builder.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { ConditionsInput } from "../types.js";
+import { buildField } from "./field-builder.js";
+
+describe("buildField", () => {
+  describe("gameType (battleFormat)", () => {
+    it("conditions undefined 時は Singles", () => {
+      const field = buildField(undefined);
+      expect(field.gameType).toBe("Singles");
+    });
+
+    it("battleFormat 未指定時は Singles", () => {
+      const field = buildField({});
+      expect(field.gameType).toBe("Singles");
+    });
+
+    it("battleFormat=\"singles\" は Singles", () => {
+      const field = buildField({ battleFormat: "singles" });
+      expect(field.gameType).toBe("Singles");
+    });
+
+    it("battleFormat=\"doubles\" は Doubles", () => {
+      const field = buildField({ battleFormat: "doubles" });
+      expect(field.gameType).toBe("Doubles");
+    });
+  });
+
+  describe("既存フィールド設定との併用", () => {
+    it("weather / terrain / battleFormat を同時に指定できる", () => {
+      const conditions: ConditionsInput = {
+        weather: "Sun",
+        terrain: "Electric",
+        battleFormat: "doubles",
+      };
+      const field = buildField(conditions);
+      expect(field.gameType).toBe("Doubles");
+      expect(field.weather).toBe("Sun");
+      expect(field.terrain).toBe("Electric");
+    });
+
+    it("doubles 指定時でも壁指定は defenderSide に伝わる", () => {
+      const field = buildField({
+        battleFormat: "doubles",
+        isReflect: true,
+        isLightScreen: true,
+        isAuroraVeil: false,
+      });
+      expect(field.gameType).toBe("Doubles");
+      expect(field.defenderSide.isReflect).toBe(true);
+      expect(field.defenderSide.isLightScreen).toBe(true);
+      expect(field.defenderSide.isAuroraVeil).toBe(false);
+    });
+  });
+});

--- a/shared/src/calc/builders/field-builder.ts
+++ b/shared/src/calc/builders/field-builder.ts
@@ -1,16 +1,32 @@
 import { Field } from "@smogon/calc";
+import type { GameType } from "@smogon/calc/dist/data/interface";
 import type { ConditionsInput } from "../types.js";
 
 /**
+ * battleFormat を @smogon/calc の GameType に変換する。
+ * 未指定 / "singles" は "Singles"、"doubles" は "Doubles"。
+ */
+function toGameType(
+  battleFormat: ConditionsInput["battleFormat"],
+): GameType {
+  return battleFormat === "doubles" ? "Doubles" : "Singles";
+}
+
+/**
  * ConditionsInput から @smogon/calc の Field オブジェクトを組み立てる。
- * conditions が undefined の場合は空の Field を返す。
+ * conditions が undefined の場合は gameType=Singles の空の Field を返す。
+ *
+ * gameType="Doubles" 指定時は @smogon/calc が以下のダブル補正を自動で適用する:
+ * - 全体攻撃技 (target: allAdjacent / allAdjacentFoes) の威力 ×0.75
+ * - リフレクター/ひかりのかべ/オーロラベールの軽減率が 0.5 → 約 0.667 倍
  */
 export function buildField(conditions: ConditionsInput | undefined): Field {
   if (conditions === undefined) {
-    return new Field();
+    return new Field({ gameType: "Singles" });
   }
 
   return new Field({
+    gameType: toGameType(conditions.battleFormat),
     weather: conditions.weather as "Sun" | "Rain" | "Sand" | "Hail" | "Snow" | undefined,
     terrain: conditions.terrain as "Electric" | "Grassy" | "Misty" | "Psychic" | undefined,
     defenderSide: {

--- a/shared/src/calc/types.ts
+++ b/shared/src/calc/types.ts
@@ -25,6 +25,7 @@ export interface PokemonInput {
 export interface ConditionsInput {
   weather?: string;
   terrain?: string;
+  battleFormat?: "singles" | "doubles";
   isReflect?: boolean;
   isLightScreen?: boolean;
   isAuroraVeil?: boolean;

--- a/shared/src/schemas/pokemon-input.ts
+++ b/shared/src/schemas/pokemon-input.ts
@@ -25,6 +25,7 @@ export type PokemonInput = {
 export type ConditionsInput = {
   weather?: string;
   terrain?: string;
+  battleFormat?: "singles" | "doubles";
   isReflect?: boolean;
   isLightScreen?: boolean;
   isAuroraVeil?: boolean;
@@ -48,6 +49,12 @@ export const pokemonSchema: z.ZodType<PokemonInput> = z.object({
 export const conditionsSchema: z.ZodType<ConditionsInput> = z.object({
   weather: z.string().optional().describe("天候（Sun, Rain, Sand, Hail, Snow）"),
   terrain: z.string().optional().describe("フィールド（Electric, Grassy, Misty, Psychic）"),
+  battleFormat: z
+    .enum(["singles", "doubles"])
+    .optional()
+    .describe(
+      "対戦形式（シングル: singles / ダブル: doubles）。省略時は singles。doubles 指定時は全体攻撃技 (じしん/ねっぷう等) の威力が ×0.75 され、壁系の軽減率が約 0.667 倍に変わる。",
+    ),
   isReflect: z.boolean().optional().describe("リフレクター"),
   isLightScreen: z.boolean().optional().describe("ひかりのかべ"),
   isAuroraVeil: z.boolean().optional().describe("オーロラベール"),


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/ai-rotom/issues/21

`ConditionsInput` / `conditionsSchema` に `battleFormat` ("singles" | "doubles") を追加し、
`@smogon/calc` の `Field` コンストラクタに `gameType` を渡すことで、ダブル時の
組み込み補正 (全体攻撃技 ×0.75 / 壁軽減率 0.5 → 約 0.667 倍 等) を有効化する。

`analyze_selection` / `find_counters` はトップレベル入力 `battleFormat` を持ちながら
ダメ計に反映していなかった (実質バグ) ため、`conditions.battleFormat` として
`DamageCalculatorAdapter` に詰め直す。トップレベル入力は後方互換のため維持する。

## Changes

* `shared/src/schemas/pokemon-input.ts` / `shared/src/calc/types.ts`: `ConditionsInput` に `battleFormat?: "singles" | "doubles"` を追加
* `shared/src/calc/builders/field-builder.ts`: `Field` の `gameType` を `battleFormat` から導出。未指定時は `"Singles"`。
* `shared/src/calc/builders/field-builder.test.ts` (新規): `gameType` 設定の単体テスト
* `packages/mcp-server/src/tools/analysis/selection-analysis.ts`: トップレベル `battleFormat` を `conditions` に詰めて calculator へ伝達
* `packages/mcp-server/src/tools/analysis/find-counters.ts`: 同上
* `packages/mcp-server/src/tools/analysis/selection-analysis.test.ts`: じしん (AoE) の doubles ダメージが ×0.75 になること / 単体技は影響を受けないこと / 省略時は singles 扱いになることを検証

## Checklist

- [x] `npm test` 全 288 件通過
- [x] `npm run build` 成功
- [x] `npm run test:dist` 7 件通過
- [x] 後方互換: トップレベル `battleFormat` 入力を維持

## その他

ダブル特有の特性個別挙動 (フレンドガード / いかく複数対象 / スキルリンク等) は
`@smogon/calc` 内蔵ロジックに委ね、個別補正は別 issue で扱う (本 PR スコープ外)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)