### PR TITLE
refactor(analyze_party_weakness): 経験則に基づく criticalWeaknesses 判定を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ e.g.) `find_counters` が呼ばれ、カバルドンの弱点タイプ（みず/
 
 > 「リザードン、ギャラドス、ピカチュウの 3 体パーティに足りないタイプ耐性は？」
 
-e.g.) `analyze_party_weakness` が呼ばれ、致命的弱点・カバーが薄いタイプをレポートします。
+e.g.) `analyze_party_weakness` が呼ばれ、各タイプを弱点に持つメンバー数（`teamWeaknesses`）と抜群を取れないタイプ（`uncoveredTypes`）を返します。致命性の判断は AI が文脈で行います。
 
 ## 既知の制限
 

--- a/packages/mcp-server/src/tools/analysis/party-analysis.ts
+++ b/packages/mcp-server/src/tools/analysis/party-analysis.ts
@@ -12,7 +12,7 @@ const CHAMPIONS_GEN_NUM = 0;
 
 const TOOL_NAME = "analyze_party_weakness";
 const TOOL_DESCRIPTION =
-  "パーティのタイプ相性を分析し、弱点と攻撃範囲の穴を洗い出す。パーティ構築の改善やバランスの確認に使用する。ポケモンチャンピオンズ対応。";
+  "パーティ各メンバーのタイプ相性データを集計する。どのタイプが何匹の弱点か（teamWeaknesses）、どのタイプに抜群を取れないか（uncoveredTypes）を返す。致命性の判断は AI が文脈で行う前提。ポケモンチャンピオンズ対応。";
 
 const partyAnalysisInputSchema = {
   party: z.array(pokemonSchema).describe("パーティメンバー"),
@@ -22,9 +22,6 @@ const partyAnalysisInputSchema = {
 const WEAKNESS_THRESHOLD = 2;
 const RESISTANCE_THRESHOLD = 1;
 const IMMUNITY_THRESHOLD = 0;
-
-/** 致命的弱点とみなすための最低弱点数 */
-const CRITICAL_WEAKNESS_MIN_COUNT = 2;
 
 /**
  * タイプ名の英語→日本語マッピング。
@@ -69,17 +66,10 @@ interface TeamWeaknessEntry {
   members: string[];
 }
 
-interface CriticalWeakness {
-  type: string;
-  weakCount: number;
-  resistCount: number;
-}
-
 interface PartyAnalysisOutput {
   members: MemberAnalysis[];
   teamWeaknesses: Record<string, TeamWeaknessEntry>;
   uncoveredTypes: string[];
-  criticalWeaknesses: CriticalWeakness[];
 }
 
 /**
@@ -194,7 +184,6 @@ export function registerPartyAnalysisTool(server: McpServer): void {
         const gen = Generations.get(CHAMPIONS_GEN_NUM);
         const members: MemberAnalysis[] = [];
         const teamWeaknesses: Record<string, TeamWeaknessEntry> = {};
-        const teamResistances: Record<string, number> = {};
         const memberTypesList: string[][] = [];
 
         for (const member of args.party) {
@@ -231,33 +220,7 @@ export function registerPartyAnalysisTool(server: McpServer): void {
             teamWeaknesses[weakness.type].count += 1;
             teamWeaknesses[weakness.type].members.push(entry.name);
           }
-
-          // パーティ全体の耐性を集計
-          for (const resistance of resistances) {
-            teamResistances[resistance.type] =
-              (teamResistances[resistance.type] ?? 0) + 1;
-          }
-          for (const immuneType of immunities) {
-            teamResistances[immuneType] =
-              (teamResistances[immuneType] ?? 0) + 1;
-          }
         }
-
-        // 致命的弱点: 弱点を突かれるメンバーが多く、耐性を持つメンバーが少ないタイプ
-        const criticalWeaknesses: CriticalWeakness[] = [];
-        for (const [type, entry] of Object.entries(teamWeaknesses)) {
-          const resistCount = teamResistances[type] ?? 0;
-          if (entry.count >= CRITICAL_WEAKNESS_MIN_COUNT) {
-            criticalWeaknesses.push({
-              type,
-              weakCount: entry.count,
-              resistCount,
-            });
-          }
-        }
-
-        // 弱点数の多い順にソート
-        criticalWeaknesses.sort((a, b) => b.weakCount - a.weakCount);
 
         // 攻撃範囲の穴を分析
         const uncoveredTypes = findUncoveredTypes(memberTypesList, gen);
@@ -266,7 +229,6 @@ export function registerPartyAnalysisTool(server: McpServer): void {
           members,
           teamWeaknesses,
           uncoveredTypes,
-          criticalWeaknesses,
         };
 
         return {


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/ai-rotom/issues/25

`analyze_party_weakness` から経験則ベース (`CRITICAL_WEAKNESS_MIN_COUNT = 2`) の `criticalWeaknesses` 判定を削除し、プロジェクト基本思想「プログラムは正確なデータを出す。AI はデータを元に考える。」に沿った設計へ揃えます。#20 (`analyze_selection`) / #22 (`find_counters`) で先行適用した方針を、パーティ分析系ツールの最後の 1 つに反映するものです。

## Changes

- `packages/mcp-server/src/tools/analysis/party-analysis.ts`
  - 定数 `CRITICAL_WEAKNESS_MIN_COUNT` を削除
  - 型 `CriticalWeakness` を削除
  - `PartyAnalysisOutput.criticalWeaknesses` 出力フィールドを削除
  - `criticalWeaknesses` 生成のためだけに使われていた `teamResistances` 集計 (resistances / immunities の加算) を削除
  - `criticalWeaknesses.sort(...)` を削除
  - `TOOL_DESCRIPTION` を改訂 (「致命性の判断は AI が文脈で行う前提」と明示)
- `README.md`
  - `analyze_party_weakness` の使用例説明を、実出力 (`teamWeaknesses` / `uncoveredTypes`) と AI 責務に整合する表現へ更新

### 維持するもの

- `members: MemberAnalysis[]` (各メンバーの弱点/耐性/無効タイプリスト)
- `teamWeaknesses: Record<string, TeamWeaknessEntry>` (タイプごとの弱点保有メンバー数とリスト)
- `uncoveredTypes: string[]` (パーティで抜群を取れないタイプ)
- タイプ相性ルール由来の定数: `WEAKNESS_THRESHOLD` / `RESISTANCE_THRESHOLD` / `IMMUNITY_THRESHOLD`

## 破壊的変更

- `analyze_party_weakness` の出力から `criticalWeaknesses` フィールドが消えます。
- #20 / #22 と同様、MCP ツールの主 consumer は AI エージェントのため、段階的 deprecation は行わず一気に削除します。npm バージョンは `0.0.x` の開発段階であり、publish 時期に合わせた bump で含めれば十分です。

## スコープ外 (issue 明記通り)

- `instructions.ts` への「致命性判断は AI が担う」明文化 → #12 で対応
- 特性による無効化・半減の考慮 (ふゆう / ちくでん / ひらいしん等)
- `analyze_party_coverage` の変更
- `uncoveredTypes` / `teamWeaknesses` の計算ロジック変更

## Checklist

- [x] `npm test` 全 281 件 pass
- [x] `npm run build` 成功 (tsdown bundle 1.70 MB)
- [x] 影響範囲 grep: `criticalWeakness` / `CRITICAL_WEAKNESS` / `CriticalWeakness` の参照は本ファイルのみ (他ツール・shared・instructions.ts では未使用)
- [x] `致命的` フレーズの残存なし (README.md 更新済み)

## その他

#20 / #22 からの連続した方針適用であり、これで `analyze_selection` / `find_counters` / `analyze_party_weakness` の 3 ツールが「経験則スコア・分類なし・生データ返却」で揃います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)