### PR TITLE
feat(analyze_party_weakness): 特性・もちものを考慮してタイプ相性を算出する

### DIFF
--- a/data/champions/items.json
+++ b/data/champions/items.json
@@ -531,6 +531,15 @@
     "megaEvolves": "Houndoom"
   },
   {
+    "id": "ironball",
+    "name": "Iron Ball",
+    "nameJa": "くろいてっきゅう",
+    "desc": "Holder's Speed is halved. Holder is grounded, and Ground-type moves become neutral against it.",
+    "shortDesc": "Holder is grounded; Ground-type moves hit it neutrally.",
+    "megaStone": null,
+    "megaEvolves": null
+  },
+  {
     "id": "kangaskhanite",
     "name": "Kangaskhanite",
     "nameJa": "ガルーラナイト",
@@ -815,6 +824,15 @@
     "nameJa": "リンドのみ",
     "desc": "Halves damage taken from a supereffective Grass-type attack. Single use.",
     "shortDesc": "Halves damage taken from a supereffective Grass-type attack. Single use.",
+    "megaStone": null,
+    "megaEvolves": null
+  },
+  {
+    "id": "ringtarget",
+    "name": "Ring Target",
+    "nameJa": "リングターゲット",
+    "desc": "Type-based immunities to attacks against the holder are removed.",
+    "shortDesc": "Holder loses type-based immunities (including Ability-based).",
     "megaStone": null,
     "megaEvolves": null
   },

--- a/data/champions/items.json
+++ b/data/champions/items.json
@@ -531,15 +531,6 @@
     "megaEvolves": "Houndoom"
   },
   {
-    "id": "ironball",
-    "name": "Iron Ball",
-    "nameJa": "くろいてっきゅう",
-    "desc": "Holder's Speed is halved. Holder is grounded, and Ground-type moves become neutral against it.",
-    "shortDesc": "Holder is grounded; Ground-type moves hit it neutrally.",
-    "megaStone": null,
-    "megaEvolves": null
-  },
-  {
     "id": "kangaskhanite",
     "name": "Kangaskhanite",
     "nameJa": "ガルーラナイト",
@@ -824,15 +815,6 @@
     "nameJa": "リンドのみ",
     "desc": "Halves damage taken from a supereffective Grass-type attack. Single use.",
     "shortDesc": "Halves damage taken from a supereffective Grass-type attack. Single use.",
-    "megaStone": null,
-    "megaEvolves": null
-  },
-  {
-    "id": "ringtarget",
-    "name": "Ring Target",
-    "nameJa": "リングターゲット",
-    "desc": "Type-based immunities to attacks against the holder are removed.",
-    "shortDesc": "Holder loses type-based immunities (including Ability-based).",
     "megaStone": null,
     "megaEvolves": null
   },

--- a/packages/mcp-server/src/tools/analysis/party-analysis.test.ts
+++ b/packages/mcp-server/src/tools/analysis/party-analysis.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Generations, toID } from "@smogon/calc";
+import type { TypeName } from "@smogon/calc/dist/data/interface";
+import {
+  applyDefensiveOverrides,
+  calculateTypeEffectiveness,
+} from "@ai-rotom/shared";
 import { pokemonNameResolver } from "../../name-resolvers";
 
 const CHAMPIONS_GEN_NUM = 0;
@@ -157,6 +162,106 @@ describe("analyze_party_weakness logic", () => {
     it("存在しないポケモン名のときに解決できない", () => {
       const result = pokemonNameResolver.toEnglish("ソニック");
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("特性・もちもの補正を反映したタイプ相性", () => {
+    /**
+     * 補正込みのタイプ相性を計算する。
+     * party-analysis.ts の calculateTypeMatchups と同等の処理を
+     * 特性・もちものを含めて再現する。
+     */
+    function computeMatchups(
+      defenderTypes: readonly TypeName[],
+      context: { ability?: string; item?: string } = {},
+    ) {
+      const weaknesses: { type: string; multiplier: number }[] = [];
+      const resistances: { type: string; multiplier: number }[] = [];
+      const immunities: string[] = [];
+
+      for (const attackType of gen.types) {
+        if (attackType.name === "???") continue;
+
+        const base = calculateTypeEffectiveness(
+          gen,
+          attackType.name,
+          defenderTypes,
+        );
+        const multiplier = applyDefensiveOverrides(
+          base,
+          attackType.name,
+          context,
+        );
+
+        if (multiplier === IMMUNITY_THRESHOLD) {
+          immunities.push(attackType.name);
+        } else if (multiplier >= WEAKNESS_THRESHOLD) {
+          weaknesses.push({ type: attackType.name, multiplier });
+        } else if (multiplier < RESISTANCE_THRESHOLD) {
+          resistances.push({ type: attackType.name, multiplier });
+        }
+      }
+
+      return { weaknesses, resistances, immunities };
+    }
+
+    it("ふゆうのフーディンで じめん が immunities に入る", () => {
+      const species = gen.species.get(toID("Alakazam"))!;
+      const types = [...species.types] as TypeName[];
+
+      const base = computeMatchups(types);
+      expect(base.immunities).not.toContain("Ground");
+
+      const withLevitate = computeMatchups(types, { ability: "Levitate" });
+      expect(withLevitate.immunities).toContain("Ground");
+    });
+
+    it("もらいびのガオガエンで ほのお が immunities に入る", () => {
+      const species = gen.species.get(toID("Incineroar"))!;
+      const types = [...species.types] as TypeName[];
+
+      const base = computeMatchups(types);
+      // ガオガエン (Fire/Dark) は ほのお を半減する
+      expect(base.resistances.some((r) => r.type === "Fire")).toBe(true);
+      expect(base.immunities).not.toContain("Fire");
+
+      const withFlashFire = computeMatchups(types, { ability: "Flash Fire" });
+      expect(withFlashFire.immunities).toContain("Fire");
+    });
+
+    it("フィルターのバンギラスで かくとう 弱点が 4 倍 → 3 倍 に下がる", () => {
+      const species = gen.species.get(toID("Tyranitar"))!;
+      const types = [...species.types] as TypeName[];
+
+      const base = computeMatchups(types);
+      const baseFighting = base.weaknesses.find((w) => w.type === "Fighting");
+      const DOUBLE_SUPER = 4;
+      expect(baseFighting).toBeDefined();
+      expect(baseFighting!.multiplier).toBe(DOUBLE_SUPER);
+
+      const withFilter = computeMatchups(types, { ability: "Filter" });
+      const filteredFighting = withFilter.weaknesses.find(
+        (w) => w.type === "Fighting",
+      );
+      const FILTER_DOUBLE_SUPER = 3;
+      expect(filteredFighting).toBeDefined();
+      expect(filteredFighting!.multiplier).toBe(FILTER_DOUBLE_SUPER);
+    });
+
+    it("リングターゲット持ちのふゆうフーディンで じめん が weaknesses に戻る", () => {
+      const species = gen.species.get(toID("Alakazam"))!;
+      const types = [...species.types] as TypeName[];
+
+      const withLevitate = computeMatchups(types, { ability: "Levitate" });
+      expect(withLevitate.immunities).toContain("Ground");
+
+      const withRingTarget = computeMatchups(types, {
+        ability: "Levitate",
+        item: "Ring Target",
+      });
+      // リングターゲットでふゆうを解除 → フーディン(エスパー単)は じめんが等倍なので
+      // weaknesses にも immunities にも入らない。ただし immunities からは消える
+      expect(withRingTarget.immunities).not.toContain("Ground");
     });
   });
 });

--- a/packages/mcp-server/src/tools/analysis/party-analysis.test.ts
+++ b/packages/mcp-server/src/tools/analysis/party-analysis.test.ts
@@ -165,15 +165,15 @@ describe("analyze_party_weakness logic", () => {
     });
   });
 
-  describe("特性・もちもの補正を反映したタイプ相性", () => {
+  describe("特性補正を反映したタイプ相性", () => {
     /**
      * 補正込みのタイプ相性を計算する。
      * party-analysis.ts の calculateTypeMatchups と同等の処理を
-     * 特性・もちものを含めて再現する。
+     * 特性を含めて再現する。
      */
     function computeMatchups(
       defenderTypes: readonly TypeName[],
-      context: { ability?: string; item?: string } = {},
+      context: { ability?: string } = {},
     ) {
       const weaknesses: { type: string; multiplier: number }[] = [];
       const resistances: { type: string; multiplier: number }[] = [];
@@ -248,20 +248,5 @@ describe("analyze_party_weakness logic", () => {
       expect(filteredFighting!.multiplier).toBe(FILTER_DOUBLE_SUPER);
     });
 
-    it("リングターゲット持ちのふゆうフーディンで じめん が weaknesses に戻る", () => {
-      const species = gen.species.get(toID("Alakazam"))!;
-      const types = [...species.types] as TypeName[];
-
-      const withLevitate = computeMatchups(types, { ability: "Levitate" });
-      expect(withLevitate.immunities).toContain("Ground");
-
-      const withRingTarget = computeMatchups(types, {
-        ability: "Levitate",
-        item: "Ring Target",
-      });
-      // リングターゲットでふゆうを解除 → フーディン(エスパー単)は じめんが等倍なので
-      // weaknesses にも immunities にも入らない。ただし immunities からは消える
-      expect(withRingTarget.immunities).not.toContain("Ground");
-    });
   });
 });

--- a/packages/mcp-server/src/tools/analysis/party-analysis.ts
+++ b/packages/mcp-server/src/tools/analysis/party-analysis.ts
@@ -2,8 +2,15 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { Generations } from "@smogon/calc";
 import type { TypeName } from "@smogon/calc/dist/data/interface";
-import { calculateTypeEffectiveness, pokemonSchema } from "@ai-rotom/shared";
 import {
+  applyDefensiveOverrides,
+  calculateTypeEffectiveness,
+  pokemonSchema,
+} from "@ai-rotom/shared";
+import type { DefensiveContextOverrides } from "@ai-rotom/shared";
+import {
+  abilityNameResolver,
+  itemNameResolver,
   pokemonNameResolver,
 } from "../../name-resolvers.js";
 import { pokemonById, toDataId } from "../../data-store.js";
@@ -95,11 +102,28 @@ function resolvePokemonName(name: string): string {
 const UNKNOWN_TYPE_NAME = "???";
 
 /**
+ * 日本語・英語のどちらの名前でも英語名に解決する。
+ * 未知の名前は undefined を返し、呼び出し側で silent ignore する。
+ */
+function resolveOptionalName(
+  resolver: typeof abilityNameResolver,
+  name: string | undefined,
+): string | undefined {
+  if (name === undefined) return undefined;
+  const english = resolver.toEnglish(name);
+  if (english !== undefined) return english;
+  if (resolver.hasEnglishName(name)) return name;
+  return undefined;
+}
+
+/**
  * ポケモンのタイプに対する各攻撃タイプの倍率を計算する。
+ * 特性・もちものが指定されていれば相性補正を適用する。
  */
 function calculateTypeMatchups(
   pokemonTypes: string[],
   gen: ReturnType<typeof Generations.get>,
+  context: DefensiveContextOverrides = {},
 ): {
   weaknesses: TypeMultiplier[];
   resistances: TypeMultiplier[];
@@ -116,11 +140,12 @@ function calculateTypeMatchups(
       continue;
     }
 
-    const multiplier = calculateTypeEffectiveness(
+    const base = calculateTypeEffectiveness(
       gen,
       attackType.name,
       defenderTypes,
     );
+    const multiplier = applyDefensiveOverrides(base, attackType.name, context);
 
     if (multiplier === IMMUNITY_THRESHOLD) {
       immunities.push(attackType.name);
@@ -200,8 +225,20 @@ export function registerPartyAnalysisTool(server: McpServer): void {
           const types = [...entry.types];
           memberTypesList.push(types);
 
+          const resolvedAbility = resolveOptionalName(
+            abilityNameResolver,
+            member.ability,
+          );
+          const resolvedItem = resolveOptionalName(
+            itemNameResolver,
+            member.item,
+          );
+
           const { weaknesses, resistances, immunities } =
-            calculateTypeMatchups(types, gen);
+            calculateTypeMatchups(types, gen, {
+              ability: resolvedAbility,
+              item: resolvedItem,
+            });
 
           members.push({
             name: entry.name,

--- a/packages/mcp-server/src/tools/analysis/party-analysis.ts
+++ b/packages/mcp-server/src/tools/analysis/party-analysis.ts
@@ -10,7 +10,6 @@ import {
 import type { DefensiveContextOverrides } from "@ai-rotom/shared";
 import {
   abilityNameResolver,
-  itemNameResolver,
   pokemonNameResolver,
 } from "../../name-resolvers.js";
 import { pokemonById, toDataId } from "../../data-store.js";
@@ -229,15 +228,10 @@ export function registerPartyAnalysisTool(server: McpServer): void {
             abilityNameResolver,
             member.ability,
           );
-          const resolvedItem = resolveOptionalName(
-            itemNameResolver,
-            member.item,
-          );
 
           const { weaknesses, resistances, immunities } =
             calculateTypeMatchups(types, gen, {
               ability: resolvedAbility,
-              item: resolvedItem,
             });
 
           members.push({

--- a/shared/src/analysis/defensive-ability-overrides.test.ts
+++ b/shared/src/analysis/defensive-ability-overrides.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { applyDefensiveOverrides } from "./defensive-ability-overrides";
+
+describe("applyDefensiveOverrides", () => {
+  const NEUTRAL = 1;
+  const IMMUNE = 0;
+  const SUPER_EFFECTIVE = 2;
+  const DOUBLE_SUPER_EFFECTIVE = 4;
+  const FILTER_SUPER = 1.5;
+  const FILTER_DOUBLE_SUPER = 3;
+  const RESIST = 0.5;
+
+  describe("特性なし・もちものなし", () => {
+    it("素のタイプ相性をそのまま返す", () => {
+      expect(applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {})).toBe(
+        SUPER_EFFECTIVE,
+      );
+      expect(applyDefensiveOverrides(NEUTRAL, "Fire", {})).toBe(NEUTRAL);
+      expect(applyDefensiveOverrides(RESIST, "Water", {})).toBe(RESIST);
+    });
+  });
+
+  describe("タイプ無効化特性", () => {
+    it("ふゆう は じめん を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          ability: "Levitate",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("もらいび は ほのお を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Fire", {
+          ability: "Flash Fire",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("ちくでん は でんき を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Electric", {
+          ability: "Volt Absorb",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("ちょすい は みず を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Water", {
+          ability: "Water Absorb",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("そうしょく は くさ を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Grass", {
+          ability: "Sap Sipper",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("ひらいしん は でんき を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Electric", {
+          ability: "Lightning Rod",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("よびみず は みず を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Water", {
+          ability: "Storm Drain",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("でんきエンジン は でんき を無効にする", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Electric", {
+          ability: "Motor Drive",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("ID 形式の特性名も受け付ける", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          ability: "levitate",
+        }),
+      ).toBe(IMMUNE);
+    });
+
+    it("対象外のタイプには影響しない（ふゆう + みず技）", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Water", {
+          ability: "Levitate",
+        }),
+      ).toBe(SUPER_EFFECTIVE);
+    });
+  });
+
+  describe("フィルター系特性", () => {
+    it("フィルターは 4 倍弱点を 3 倍に補正する", () => {
+      expect(
+        applyDefensiveOverrides(DOUBLE_SUPER_EFFECTIVE, "Fighting", {
+          ability: "Filter",
+        }),
+      ).toBe(FILTER_DOUBLE_SUPER);
+    });
+
+    it("フィルターは 2 倍弱点を 1.5 倍に補正する", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          ability: "Filter",
+        }),
+      ).toBe(FILTER_SUPER);
+    });
+
+    it("ハードロックも同等に補正する", () => {
+      expect(
+        applyDefensiveOverrides(DOUBLE_SUPER_EFFECTIVE, "Fighting", {
+          ability: "Solid Rock",
+        }),
+      ).toBe(FILTER_DOUBLE_SUPER);
+    });
+
+    it("等倍・半減には影響しない", () => {
+      expect(
+        applyDefensiveOverrides(NEUTRAL, "Normal", { ability: "Filter" }),
+      ).toBe(NEUTRAL);
+      expect(
+        applyDefensiveOverrides(RESIST, "Fire", { ability: "Filter" }),
+      ).toBe(RESIST);
+    });
+  });
+
+  describe("リングターゲット", () => {
+    it("ふゆう特性のじめん無効を解除する", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          ability: "Levitate",
+          item: "Ring Target",
+        }),
+      ).toBe(SUPER_EFFECTIVE);
+    });
+
+    it("もらいび特性のほのお無効を解除する", () => {
+      expect(
+        applyDefensiveOverrides(NEUTRAL, "Fire", {
+          ability: "Flash Fire",
+          item: "Ring Target",
+        }),
+      ).toBe(NEUTRAL);
+    });
+
+    it("ID 形式のもちもの名も受け付ける", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          ability: "Levitate",
+          item: "ringtarget",
+        }),
+      ).toBe(SUPER_EFFECTIVE);
+    });
+  });
+
+  describe("くろいてっきゅう", () => {
+    it("ひこうタイプのじめん無効 (0 倍) を等倍に戻す", () => {
+      expect(
+        applyDefensiveOverrides(IMMUNE, "Ground", { item: "Iron Ball" }),
+      ).toBe(NEUTRAL);
+    });
+
+    it("ふゆう特性のじめん無効も等倍に戻す（base が 0 になっている想定ではなく、特性無効化経路も解除）", () => {
+      // ふゆう持ち (飛行タイプではない) の base は通常倍率（2 倍など）で来る
+      // くろいてっきゅうは 0 倍を 1 に戻すため、base=2 のまま。
+      // さらに特性による 0 倍化を抑止するために ability を無視する挙動も期待したい。
+      // ただし本関数は「もちものは特性より優先」で、ここでは ability を単独で適用しても
+      // じめん技が通ることを確認する
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          ability: "Levitate",
+          item: "Iron Ball",
+        }),
+      ).toBe(SUPER_EFFECTIVE);
+    });
+
+    it("じめん以外には影響しない", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Water", {
+          item: "Iron Ball",
+        }),
+      ).toBe(SUPER_EFFECTIVE);
+    });
+  });
+
+  describe("未知の名前", () => {
+    it("未知の特性名は無視する", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          ability: "UnknownAbility",
+        }),
+      ).toBe(SUPER_EFFECTIVE);
+    });
+
+    it("未知のもちもの名は無視する", () => {
+      expect(
+        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
+          item: "UnknownItem",
+        }),
+      ).toBe(SUPER_EFFECTIVE);
+    });
+  });
+});

--- a/shared/src/analysis/defensive-ability-overrides.test.ts
+++ b/shared/src/analysis/defensive-ability-overrides.test.ts
@@ -10,7 +10,7 @@ describe("applyDefensiveOverrides", () => {
   const FILTER_DOUBLE_SUPER = 3;
   const RESIST = 0.5;
 
-  describe("特性なし・もちものなし", () => {
+  describe("特性なし", () => {
     it("素のタイプ相性をそのまま返す", () => {
       expect(applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {})).toBe(
         SUPER_EFFECTIVE,
@@ -137,78 +137,11 @@ describe("applyDefensiveOverrides", () => {
     });
   });
 
-  describe("リングターゲット", () => {
-    it("ふゆう特性のじめん無効を解除する", () => {
-      expect(
-        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
-          ability: "Levitate",
-          item: "Ring Target",
-        }),
-      ).toBe(SUPER_EFFECTIVE);
-    });
-
-    it("もらいび特性のほのお無効を解除する", () => {
-      expect(
-        applyDefensiveOverrides(NEUTRAL, "Fire", {
-          ability: "Flash Fire",
-          item: "Ring Target",
-        }),
-      ).toBe(NEUTRAL);
-    });
-
-    it("ID 形式のもちもの名も受け付ける", () => {
-      expect(
-        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
-          ability: "Levitate",
-          item: "ringtarget",
-        }),
-      ).toBe(SUPER_EFFECTIVE);
-    });
-  });
-
-  describe("くろいてっきゅう", () => {
-    it("ひこうタイプのじめん無効 (0 倍) を等倍に戻す", () => {
-      expect(
-        applyDefensiveOverrides(IMMUNE, "Ground", { item: "Iron Ball" }),
-      ).toBe(NEUTRAL);
-    });
-
-    it("ふゆう特性のじめん無効も等倍に戻す（base が 0 になっている想定ではなく、特性無効化経路も解除）", () => {
-      // ふゆう持ち (飛行タイプではない) の base は通常倍率（2 倍など）で来る
-      // くろいてっきゅうは 0 倍を 1 に戻すため、base=2 のまま。
-      // さらに特性による 0 倍化を抑止するために ability を無視する挙動も期待したい。
-      // ただし本関数は「もちものは特性より優先」で、ここでは ability を単独で適用しても
-      // じめん技が通ることを確認する
-      expect(
-        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
-          ability: "Levitate",
-          item: "Iron Ball",
-        }),
-      ).toBe(SUPER_EFFECTIVE);
-    });
-
-    it("じめん以外には影響しない", () => {
-      expect(
-        applyDefensiveOverrides(SUPER_EFFECTIVE, "Water", {
-          item: "Iron Ball",
-        }),
-      ).toBe(SUPER_EFFECTIVE);
-    });
-  });
-
   describe("未知の名前", () => {
     it("未知の特性名は無視する", () => {
       expect(
         applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
           ability: "UnknownAbility",
-        }),
-      ).toBe(SUPER_EFFECTIVE);
-    });
-
-    it("未知のもちもの名は無視する", () => {
-      expect(
-        applyDefensiveOverrides(SUPER_EFFECTIVE, "Ground", {
-          item: "UnknownItem",
         }),
       ).toBe(SUPER_EFFECTIVE);
     });

--- a/shared/src/analysis/defensive-ability-overrides.ts
+++ b/shared/src/analysis/defensive-ability-overrides.ts
@@ -1,0 +1,121 @@
+import type { TypeName } from "@smogon/calc/dist/data/interface";
+
+/**
+ * 防御側の特性・もちものに応じて、タイプ相性倍率を補正するための入力。
+ *
+ * ability / item は英語名（@smogon/calc 互換の "Levitate" / "Ring Target" 等）
+ * または ID（"levitate" / "ringtarget" 等）を受け付ける。呼び出し側で事前に
+ * 正規化して渡すこと。未知の値はそのまま無視する。
+ */
+export interface DefensiveContextOverrides {
+  ability?: string;
+  item?: string;
+}
+
+/** 等倍 */
+const NEUTRAL_MULTIPLIER = 1;
+
+/** 無効（0 倍） */
+const IMMUNE_MULTIPLIER = 0;
+
+/** フィルター系特性が抜群時に掛ける倍率 (3/4 = 0.75) */
+const FILTER_SUPER_EFFECTIVE_MULTIPLIER = 0.75;
+
+/** 効果抜群とみなす最低倍率 */
+const SUPER_EFFECTIVE_THRESHOLD = 2;
+
+/** 文字列を ID 相当（英数字のみ・小文字）に正規化する */
+function toId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * タイプ相性を無効化する特性 ID → 無効にする攻撃タイプのマップ。
+ * ぼうおん（Soundproof）は「おと系技」という技フラグ依存で、タイプ相性では
+ * 表現できないためここには含めない（issue スコープ外）。
+ */
+const TYPE_IMMUNITY_ABILITIES: ReadonlyMap<string, TypeName> = new Map([
+  ["levitate", "Ground"],
+  ["flashfire", "Fire"],
+  ["waterabsorb", "Water"],
+  ["voltabsorb", "Electric"],
+  ["lightningrod", "Electric"],
+  ["motordrive", "Electric"],
+  ["stormdrain", "Water"],
+  ["sapsipper", "Grass"],
+]);
+
+/** 効果抜群時に 0.75 倍にする特性 ID のセット */
+const FILTER_LIKE_ABILITIES: ReadonlySet<string> = new Set([
+  "filter",
+  "solidrock",
+  "prismarmor",
+]);
+
+/** リングターゲット: 特性・タイプによる無効化を解除する */
+const RING_TARGET_ITEM_ID = "ringtarget";
+
+/** くろいてっきゅう: じめん技の無効化を解除する（タイプ・特性の両方） */
+const IRON_BALL_ITEM_ID = "ironball";
+
+/**
+ * 特性・もちものを加味したタイプ相性補正を適用する。
+ *
+ * 優先順位:
+ *   1. もちもの（リングターゲット / くろいてっきゅう）による無効解除
+ *      → 特性の無効化・タイプによる 0 倍化の両方をキャンセルする
+ *   2. 特性による無効化（もちもので解除されていない場合）
+ *   3. フィルター系の 0.75 倍（抜群時のみ）
+ *
+ * @param baseMultiplier 純粋なタイプ相性計算の結果
+ * @param attackingType 攻撃側の技タイプ
+ * @param context 防御側の ability / item（英語名 or ID）
+ * @returns 補正後の倍率
+ */
+export function applyDefensiveOverrides(
+  baseMultiplier: number,
+  attackingType: TypeName,
+  context: DefensiveContextOverrides,
+): number {
+  const abilityId =
+    context.ability !== undefined ? toId(context.ability) : undefined;
+  const itemId = context.item !== undefined ? toId(context.item) : undefined;
+
+  const hasRingTarget = itemId === RING_TARGET_ITEM_ID;
+  const hasIronBall = itemId === IRON_BALL_ITEM_ID;
+
+  let multiplier = baseMultiplier;
+
+  // もちものによる「タイプ由来の 0 倍化」解除。
+  // - リングターゲット: あらゆるタイプ無効を等倍に戻す
+  // - くろいてっきゅう: じめん技の無効（ひこう / ふゆう等の合成結果）を等倍に戻す
+  if (multiplier === IMMUNE_MULTIPLIER) {
+    if (hasRingTarget) {
+      multiplier = NEUTRAL_MULTIPLIER;
+    } else if (hasIronBall && attackingType === "Ground") {
+      multiplier = NEUTRAL_MULTIPLIER;
+    }
+  }
+
+  // 特性による無効化判定。
+  // リングターゲット所持時、または くろいてっきゅう 所持時の じめん技 は特性を上書きしない。
+  const ignoreAbilityImmunity =
+    hasRingTarget || (hasIronBall && attackingType === "Ground");
+  if (abilityId !== undefined && !ignoreAbilityImmunity) {
+    const immuneType = TYPE_IMMUNITY_ABILITIES.get(abilityId);
+    if (immuneType !== undefined && attackingType === immuneType) {
+      return IMMUNE_MULTIPLIER;
+    }
+  }
+
+  // フィルター系の 0.75 倍（抜群時のみ）
+  if (
+    abilityId !== undefined &&
+    FILTER_LIKE_ABILITIES.has(abilityId) &&
+    multiplier >= SUPER_EFFECTIVE_THRESHOLD
+  ) {
+    multiplier *= FILTER_SUPER_EFFECTIVE_MULTIPLIER;
+  }
+
+  return multiplier;
+}

--- a/shared/src/analysis/defensive-ability-overrides.ts
+++ b/shared/src/analysis/defensive-ability-overrides.ts
@@ -1,19 +1,15 @@
 import type { TypeName } from "@smogon/calc/dist/data/interface";
 
 /**
- * 防御側の特性・もちものに応じて、タイプ相性倍率を補正するための入力。
+ * 防御側の特性に応じて、タイプ相性倍率を補正するための入力。
  *
- * ability / item は英語名（@smogon/calc 互換の "Levitate" / "Ring Target" 等）
- * または ID（"levitate" / "ringtarget" 等）を受け付ける。呼び出し側で事前に
- * 正規化して渡すこと。未知の値はそのまま無視する。
+ * ability は英語名（@smogon/calc 互換の "Levitate" 等）または ID
+ * （"levitate" 等）を受け付ける。呼び出し側で事前に正規化して渡すこと。
+ * 未知の値はそのまま無視する。
  */
 export interface DefensiveContextOverrides {
   ability?: string;
-  item?: string;
 }
-
-/** 等倍 */
-const NEUTRAL_MULTIPLIER = 1;
 
 /** 無効（0 倍） */
 const IMMUNE_MULTIPLIER = 0;
@@ -52,24 +48,16 @@ const FILTER_LIKE_ABILITIES: ReadonlySet<string> = new Set([
   "prismarmor",
 ]);
 
-/** リングターゲット: 特性・タイプによる無効化を解除する */
-const RING_TARGET_ITEM_ID = "ringtarget";
-
-/** くろいてっきゅう: じめん技の無効化を解除する（タイプ・特性の両方） */
-const IRON_BALL_ITEM_ID = "ironball";
-
 /**
- * 特性・もちものを加味したタイプ相性補正を適用する。
+ * 特性を加味したタイプ相性補正を適用する。
  *
  * 優先順位:
- *   1. もちもの（リングターゲット / くろいてっきゅう）による無効解除
- *      → 特性の無効化・タイプによる 0 倍化の両方をキャンセルする
- *   2. 特性による無効化（もちもので解除されていない場合）
- *   3. フィルター系の 0.75 倍（抜群時のみ）
+ *   1. 特性による無効化
+ *   2. フィルター系の 0.75 倍（抜群時のみ）
  *
  * @param baseMultiplier 純粋なタイプ相性計算の結果
  * @param attackingType 攻撃側の技タイプ
- * @param context 防御側の ability / item（英語名 or ID）
+ * @param context 防御側の ability（英語名 or ID）
  * @returns 補正後の倍率
  */
 export function applyDefensiveOverrides(
@@ -79,29 +67,11 @@ export function applyDefensiveOverrides(
 ): number {
   const abilityId =
     context.ability !== undefined ? toId(context.ability) : undefined;
-  const itemId = context.item !== undefined ? toId(context.item) : undefined;
-
-  const hasRingTarget = itemId === RING_TARGET_ITEM_ID;
-  const hasIronBall = itemId === IRON_BALL_ITEM_ID;
 
   let multiplier = baseMultiplier;
 
-  // もちものによる「タイプ由来の 0 倍化」解除。
-  // - リングターゲット: あらゆるタイプ無効を等倍に戻す
-  // - くろいてっきゅう: じめん技の無効（ひこう / ふゆう等の合成結果）を等倍に戻す
-  if (multiplier === IMMUNE_MULTIPLIER) {
-    if (hasRingTarget) {
-      multiplier = NEUTRAL_MULTIPLIER;
-    } else if (hasIronBall && attackingType === "Ground") {
-      multiplier = NEUTRAL_MULTIPLIER;
-    }
-  }
-
   // 特性による無効化判定。
-  // リングターゲット所持時、または くろいてっきゅう 所持時の じめん技 は特性を上書きしない。
-  const ignoreAbilityImmunity =
-    hasRingTarget || (hasIronBall && attackingType === "Ground");
-  if (abilityId !== undefined && !ignoreAbilityImmunity) {
+  if (abilityId !== undefined) {
     const immuneType = TYPE_IMMUNITY_ABILITIES.get(abilityId);
     if (immuneType !== undefined && attackingType === immuneType) {
       return IMMUNE_MULTIPLIER;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./analysis/type-matchup";
 export * from "./analysis/stat-calculator";
 export * from "./analysis/speed-comparator";
 export * from "./analysis/priority-moves";
+export * from "./analysis/defensive-ability-overrides";
 export * from "./schemas/pokemon-input";
 export * from "./schemas/stats";
 export type {


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/ai-rotom/issues/26

`analyze_party_weakness` は `pokemonSchema` で ability を受け取りながら、
タイプ相性計算時にそれを無視していた。本 PR で ability を反映し、以下のような
実戦想定と乖離していた結果を改善する。

- ふゆうのフーディン → じめん が immunities に入る
- もらいびのガオガエン → ほのお が immunities に入る
- フィルターのバンギラス → かくとう 4 倍弱点が 3 倍 (1.5 倍相当) に下がる

## Changes

* `shared/src/analysis/defensive-ability-overrides.ts` を新規追加
  - `applyDefensiveOverrides(base, attackingType, { ability })` 純関数
  - 無効化特性: ふゆう / もらいび / ちくでん / ちょすい / そうしょく /
    ひらいしん / よびみず / でんきエンジン
  - 0.75 倍特性: フィルター / ハードロック / プリズムアーマー
  - ぼうおん は技フラグ依存のためタイプ相性では表現できず、スコープ外
* `shared/src/index.ts` で新モジュールを re-export
* `packages/mcp-server/src/tools/analysis/party-analysis.ts`
  - 各メンバーの `ability` を `abilityNameResolver` で英語名に正規化してから
    `calculateTypeMatchups` に渡す
  - 未知の名前は silent ignore し、分析自体は失敗させない
* ユニットテスト / 統合テストを追加 (issue 記載の 3 シナリオをカバー)

## Checklist

- [x] \`npm test\` (387 passed)
- [x] \`npm run build\` (成功)
- [x] \`npm run test:dist\` (7 passed)
- [x] \`bash scripts/verify-dist-bundle.sh\` (成功)
- [x] ふゆうフーディン / もらいびガオガエン / フィルターバンギラス のテストを追加

## その他

スコープ外:
- ダメージ計算 (\`analyze_party_weakness\` はタイプ相性のみ)
- 状態異常系特性 / 威力補正系特性
- \`analyze_matchup\` / \`find_counters\` / \`analyze_party_coverage\` への展開 (別 issue)
- ぼうおん (技フラグ依存のためタイプ相性では表現不可)
- タイプ相性を変えるもちもの (リングターゲット / くろいてっきゅう)
  攻略サイト複数でポケモンチャンピオンズ未実装を確認したため、本 PR では
  見送り。将来公式実装された時点で \`DefensiveContextOverrides\` に
  \`item\` フィールドを再追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)