### PR TITLE
feat(analyze_party_coverage): タイプ変更系特性を考慮してカバレッジを算出する

### DIFF
--- a/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
@@ -276,5 +276,24 @@ describe("analyze_party_coverage logic", () => {
       const normal = out.coverage.find((c) => c.defenderType === "Normal");
       expect(normal?.bestAttackers[0].effectiveType).toBeUndefined();
     });
+
+    it("日本語特性名（フェアリースキン）でも解決されて変換される", () => {
+      const PIXILATE_JA = {
+        name: "メガチルタリス",
+        ability: "フェアリースキン",
+      };
+      const out = analyzePartyCoverage({
+        myParty: [PIXILATE_JA],
+        moves: { メガチルタリス: ["Hyper Beam"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(false);
+
+      const SUPER_EFFECTIVE = 2;
+      const dragon = out.coverage.find((c) => c.defenderType === "Dragon");
+      expect(dragon?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(dragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+    });
   });
 });

--- a/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
@@ -169,5 +169,112 @@ describe("analyze_party_coverage logic", () => {
       expect(electric?.bestAttackers).toHaveLength(1);
       expect(electric?.bestAttackers[0].move).toBe("Earthquake");
     });
+
+    it("特性なし + ノーマル技は effectiveType が設定されない（regression）", () => {
+      const NORMAL_ATTACKER = { name: "ガブリアス" };
+      const NORMAL_MOVE_SET = { ガブリアス: ["Hyper Beam"] };
+      const out = analyzePartyCoverage({
+        myParty: [NORMAL_ATTACKER],
+        moves: NORMAL_MOVE_SET,
+      });
+      const normal = out.coverage.find((c) => c.defenderType === "Normal");
+      const attacker = normal?.bestAttackers[0];
+      expect(attacker?.move).toBe("Hyper Beam");
+      expect(attacker?.effectiveType).toBeUndefined();
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(false);
+    });
+  });
+
+  describe("タイプ変更系特性の反映", () => {
+    // メガチルタリス (altariamega) は pixilate を持つ
+    const PIXILATE_MEGA = {
+      name: "メガチルタリス",
+      ability: "フェアリースキン",
+    };
+
+    it("Pixilate + Hyper Beam → Fairy として評価される", () => {
+      const out = analyzePartyCoverage({
+        myParty: [PIXILATE_MEGA],
+        moves: { メガチルタリス: ["Hyper Beam"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(false);
+
+      // Fairy は Dragon に 2 倍
+      const SUPER_EFFECTIVE = 2;
+      const dragon = out.coverage.find((c) => c.defenderType === "Dragon");
+      expect(dragon?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(dragon?.bestAttackers[0].move).toBe("Hyper Beam");
+      expect(dragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+    });
+
+    it("Pixilate + Hyper Beam は Steel に半減（元ノーマルの等倍から変化）", () => {
+      const HALF_EFFECTIVE = 0.5;
+      const out = analyzePartyCoverage({
+        myParty: [PIXILATE_MEGA],
+        moves: { メガチルタリス: ["Hyper Beam"] },
+      });
+      const steel = out.coverage.find((c) => c.defenderType === "Steel");
+      expect(steel?.maxMultiplier).toBe(HALF_EFFECTIVE);
+      expect(out.uncoveredTypes.some((t) => t.type === "Steel")).toBe(true);
+    });
+
+    it("Pixilate + Earthquake は Ground のまま (非ノーマル技はスルー)", () => {
+      const out = analyzePartyCoverage({
+        myParty: [PIXILATE_MEGA],
+        moves: { メガチルタリス: ["Earthquake"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Ground")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(false);
+
+      // Fire は Ground に 2 倍（Fairy は等倍のため、変換されていたら値が 1 になる）
+      const SUPER_EFFECTIVE = 2;
+      const fire = out.coverage.find((c) => c.defenderType === "Fire");
+      expect(fire?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(fire?.bestAttackers[0].effectiveType).toBeUndefined();
+    });
+
+    it("Galvanize + Body Slam → Electric として評価される", () => {
+      const GALVANIZE_ATTACKER = {
+        name: "サンダース",
+        ability: "エレキスキン",
+      };
+      const out = analyzePartyCoverage({
+        myParty: [GALVANIZE_ATTACKER],
+        moves: { サンダース: ["Body Slam"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Electric")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(false);
+
+      // Electric は Water に 2 倍
+      const SUPER_EFFECTIVE = 2;
+      const water = out.coverage.find((c) => c.defenderType === "Water");
+      expect(water?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(water?.bestAttackers[0].effectiveType).toBe("Electric");
+
+      // Ground には 0 倍
+      const NO_EFFECT = 0;
+      const ground = out.coverage.find((c) => c.defenderType === "Ground");
+      expect(ground?.maxMultiplier).toBe(NO_EFFECT);
+    });
+
+    it("未知の特性は silent fallback で元タイプ維持", () => {
+      const UNKNOWN_ABILITY_ATTACKER = {
+        name: "ガブリアス",
+        ability: "そんなとくせいない",
+      };
+      const out = analyzePartyCoverage({
+        myParty: [UNKNOWN_ABILITY_ATTACKER],
+        moves: { ガブリアス: ["Hyper Beam"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(true);
+      const normal = out.coverage.find((c) => c.defenderType === "Normal");
+      expect(normal?.bestAttackers[0].effectiveType).toBeUndefined();
+    });
   });
 });

--- a/packages/mcp-server/src/tools/analysis/party-coverage.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { Generations } from "@smogon/calc";
 import type { TypeName } from "@smogon/calc/dist/data/interface";
 import {
+  applyOffensiveTypeOverride,
   calculateTypeEffectiveness,
   pokemonSchema,
   type PokemonInput,
@@ -18,7 +19,10 @@ import {
   type PokemonEntry,
   type TypeEntry,
 } from "../../data-store.js";
-import { pokemonNameResolver } from "../../name-resolvers.js";
+import {
+  abilityNameResolver,
+  pokemonNameResolver,
+} from "../../name-resolvers.js";
 
 const CHAMPIONS_GEN_NUM = 0;
 
@@ -58,6 +62,11 @@ interface BestAttackerEntry {
   pokemon: string;
   move: string;
   multiplier: number;
+  /**
+   * 特性によってタイプ変換された場合の実効タイプ。
+   * 元タイプと同じ場合は省略する（例: Pixilate + Hyper Beam → "Fairy"）。
+   */
+  effectiveType?: string;
 }
 
 interface CoverageEntry {
@@ -115,6 +124,27 @@ function resolveAttackingMoveIds(
     }
   }
   return moves;
+}
+
+/**
+ * 特性名（日本語 or 英語）を正規化済みの特性 ID に変換する。
+ * 未指定・解決不能な場合は undefined を返す（silent fallback）。
+ *
+ * 未知の特性文字列でエラーにしないのは、party_coverage が
+ * 「構築入力を緩く受け取る」UX を取っているため。
+ * 未知の特性は単に override なし扱いとする。
+ */
+function resolveAbilityId(abilityName: string | undefined): string | undefined {
+  if (abilityName === undefined) {
+    return undefined;
+  }
+  const englishName =
+    abilityNameResolver.toEnglish(abilityName) ??
+    (abilityNameResolver.hasEnglishName(abilityName) ? abilityName : undefined);
+  if (englishName === undefined) {
+    return undefined;
+  }
+  return toDataId(englishName);
 }
 
 /**
@@ -189,6 +219,7 @@ export function analyzePartyCoverage(
   interface MemberWithMoves {
     entry: PokemonEntry;
     attackingMoves: MoveEntry[];
+    abilityId: string | undefined;
   }
 
   const members: MemberWithMoves[] = [];
@@ -198,12 +229,18 @@ export function analyzePartyCoverage(
     const entry = resolvePokemonEntry(member.name);
     const explicitMoves = movesMap.get(entry.id);
     const attackingMoves = resolveAttackingMoveIds(entry, explicitMoves);
+    const abilityId = resolveAbilityId(member.ability);
 
     for (const move of attackingMoves) {
-      attackingTypesSet.add(move.type);
+      const effectiveType = applyOffensiveTypeOverride(
+        move.type as TypeName,
+        move.category,
+        abilityId,
+      );
+      attackingTypesSet.add(effectiveType);
     }
 
-    members.push({ entry, attackingMoves });
+    members.push({ entry, attackingMoves, abilityId });
   }
 
   const attackingTypes: AttackingTypeEntry[] = [];
@@ -227,29 +264,34 @@ export function analyzePartyCoverage(
 
     for (const member of members) {
       for (const move of member.attackingMoves) {
+        const effectiveType = applyOffensiveTypeOverride(
+          move.type as TypeName,
+          move.category,
+          member.abilityId,
+        );
         const multiplier = getEffectivenessForDefenderType(
-          move.type,
+          effectiveType,
           defenderType.name,
           gen,
         );
+        const attacker: BestAttackerEntry = {
+          pokemon: member.entry.name,
+          move: move.name,
+          multiplier,
+        };
+        if (effectiveType !== move.type) {
+          attacker.effectiveType = effectiveType;
+        }
         if (multiplier > maxMultiplier) {
           maxMultiplier = multiplier;
           bestAttackers.length = 0;
-          bestAttackers.push({
-            pokemon: member.entry.name,
-            move: move.name,
-            multiplier,
-          });
+          bestAttackers.push(attacker);
         } else if (multiplier === maxMultiplier && multiplier > 0) {
           const alreadyHasSamePokemon = bestAttackers.some(
             (ba) => ba.pokemon === member.entry.name,
           );
           if (!alreadyHasSamePokemon) {
-            bestAttackers.push({
-              pokemon: member.entry.name,
-              move: move.name,
-              multiplier,
-            });
+            bestAttackers.push(attacker);
           }
         }
       }

--- a/packages/mcp-server/src/tools/analysis/party-coverage.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.ts
@@ -127,24 +127,22 @@ function resolveAttackingMoveIds(
 }
 
 /**
- * 特性名（日本語 or 英語）を正規化済みの特性 ID に変換する。
- * 未指定・解決不能な場合は undefined を返す（silent fallback）。
+ * 日本語・英語のどちらの名前でも英語名に解決する。
+ * 未知の名前は undefined を返し、呼び出し側で silent ignore する。
  *
  * 未知の特性文字列でエラーにしないのは、party_coverage が
  * 「構築入力を緩く受け取る」UX を取っているため。
  * 未知の特性は単に override なし扱いとする。
  */
-function resolveAbilityId(abilityName: string | undefined): string | undefined {
-  if (abilityName === undefined) {
-    return undefined;
-  }
-  const englishName =
-    abilityNameResolver.toEnglish(abilityName) ??
-    (abilityNameResolver.hasEnglishName(abilityName) ? abilityName : undefined);
-  if (englishName === undefined) {
-    return undefined;
-  }
-  return toDataId(englishName);
+function resolveOptionalName(
+  resolver: typeof abilityNameResolver,
+  name: string | undefined,
+): string | undefined {
+  if (name === undefined) return undefined;
+  const english = resolver.toEnglish(name);
+  if (english !== undefined) return english;
+  if (resolver.hasEnglishName(name)) return name;
+  return undefined;
 }
 
 /**
@@ -219,7 +217,7 @@ export function analyzePartyCoverage(
   interface MemberWithMoves {
     entry: PokemonEntry;
     attackingMoves: MoveEntry[];
-    abilityId: string | undefined;
+    ability: string | undefined;
   }
 
   const members: MemberWithMoves[] = [];
@@ -229,18 +227,18 @@ export function analyzePartyCoverage(
     const entry = resolvePokemonEntry(member.name);
     const explicitMoves = movesMap.get(entry.id);
     const attackingMoves = resolveAttackingMoveIds(entry, explicitMoves);
-    const abilityId = resolveAbilityId(member.ability);
+    const ability = resolveOptionalName(abilityNameResolver, member.ability);
 
     for (const move of attackingMoves) {
       const effectiveType = applyOffensiveTypeOverride(
         move.type as TypeName,
         move.category,
-        abilityId,
+        ability,
       );
       attackingTypesSet.add(effectiveType);
     }
 
-    members.push({ entry, attackingMoves, abilityId });
+    members.push({ entry, attackingMoves, ability });
   }
 
   const attackingTypes: AttackingTypeEntry[] = [];
@@ -267,7 +265,7 @@ export function analyzePartyCoverage(
         const effectiveType = applyOffensiveTypeOverride(
           move.type as TypeName,
           move.category,
-          member.abilityId,
+          member.ability,
         );
         const multiplier = getEffectivenessForDefenderType(
           effectiveType,

--- a/shared/src/analysis/offensive-ability-overrides.test.ts
+++ b/shared/src/analysis/offensive-ability-overrides.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyOffensiveTypeOverride,
+  OFFENSIVE_TYPE_OVERRIDES,
+} from "./offensive-ability-overrides";
+
+describe("applyOffensiveTypeOverride", () => {
+  describe("タイプ変更系特性 × ノーマル技", () => {
+    it("pixilate + ノーマル物理技 → Fairy", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "pixilate"),
+      ).toBe("Fairy");
+    });
+
+    it("pixilate + ノーマル特殊技 → Fairy", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Special", "pixilate"),
+      ).toBe("Fairy");
+    });
+
+    it("galvanize + ノーマル技 → Electric", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "galvanize"),
+      ).toBe("Electric");
+    });
+
+    it("refrigerate + ノーマル技 → Ice", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "refrigerate"),
+      ).toBe("Ice");
+    });
+
+    it("aerilate + ノーマル技 → Flying", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "aerilate"),
+      ).toBe("Flying");
+    });
+  });
+
+  describe("変換されないケース", () => {
+    it("特性 undefined → 原型", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", undefined),
+      ).toBe("Normal");
+    });
+
+    it("非ノーマル技は特性があっても変換されない (pixilate + じしん)", () => {
+      expect(
+        applyOffensiveTypeOverride("Ground", "Physical", "pixilate"),
+      ).toBe("Ground");
+    });
+
+    it("ノーマルの Status 技は変換されない (pixilate + すてみタックル相当の変化技)", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Status", "pixilate"),
+      ).toBe("Normal");
+    });
+
+    it("未知の特性は変換されない (silent fallback)", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "unknownability"),
+      ).toBe("Normal");
+    });
+
+    it("非変換系の既知特性は変換されない (intimidate 等)", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "intimidate"),
+      ).toBe("Normal");
+    });
+  });
+
+  describe("OFFENSIVE_TYPE_OVERRIDES のエクスポート", () => {
+    it("4 特性すべてがマップに含まれる", () => {
+      const EXPECTED_ENTRIES = 4;
+      expect(OFFENSIVE_TYPE_OVERRIDES.size).toBe(EXPECTED_ENTRIES);
+      expect(OFFENSIVE_TYPE_OVERRIDES.get("pixilate")).toBe("Fairy");
+      expect(OFFENSIVE_TYPE_OVERRIDES.get("galvanize")).toBe("Electric");
+      expect(OFFENSIVE_TYPE_OVERRIDES.get("refrigerate")).toBe("Ice");
+      expect(OFFENSIVE_TYPE_OVERRIDES.get("aerilate")).toBe("Flying");
+    });
+  });
+});

--- a/shared/src/analysis/offensive-ability-overrides.test.ts
+++ b/shared/src/analysis/offensive-ability-overrides.test.ts
@@ -35,6 +35,18 @@ describe("applyOffensiveTypeOverride", () => {
         applyOffensiveTypeOverride("Normal", "Physical", "aerilate"),
       ).toBe("Flying");
     });
+
+    it("英語名（先頭大文字）でも正規化されて変換される (Pixilate)", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "Pixilate"),
+      ).toBe("Fairy");
+    });
+
+    it("ハイフン・空白混じりでも正規化で通る ('  Pix-ilate ')", () => {
+      expect(
+        applyOffensiveTypeOverride("Normal", "Physical", "  Pix-ilate "),
+      ).toBe("Fairy");
+    });
   });
 
   describe("変換されないケース", () => {

--- a/shared/src/analysis/offensive-ability-overrides.ts
+++ b/shared/src/analysis/offensive-ability-overrides.ts
@@ -1,0 +1,68 @@
+import type { TypeName } from "@smogon/calc/dist/data/interface";
+
+/**
+ * タイプ変更系特性（skin abilities）を扱う純関数モジュール。
+ *
+ * ノーマル技を別タイプに変換する特性の効果を、カバレッジ計算など
+ * 「タイプ相性のみ」を扱うツール向けに反映させる。
+ * 威力補正（1.2 倍）はここでは扱わない（ダメージ計算側の責務）。
+ */
+
+/** ノーマル技は `move.type === "Normal"` を満たす */
+const NORMAL_TYPE: TypeName = "Normal";
+
+/**
+ * 変化技のカテゴリ。変化技にはタイプ変更系特性は乗らない。
+ * mcp-server 側の MoveCategory と同じ文字列だが、shared は mcp-server に
+ * 依存できないためここで独立に定義する。
+ */
+const STATUS_CATEGORY = "Status" as const;
+
+/** 本モジュールが受け付ける技カテゴリ */
+export type OffensiveMoveCategory = "Physical" | "Special" | "Status";
+
+/**
+ * 特性 ID → 変換後タイプのマップ。
+ * キーは `toID` 相当で正規化済みの特性 ID（例: "pixilate"）。
+ *
+ * `data/champions/abilities.json` の id と一致する。呼び出し側は
+ * 日本語特性名を `abilityNameResolver.toEnglish` → `toDataId` の順で
+ * 正規化してから渡す責務を持つ。
+ */
+export const OFFENSIVE_TYPE_OVERRIDES: ReadonlyMap<string, TypeName> = new Map([
+  ["pixilate", "Fairy"],
+  ["galvanize", "Electric"],
+  ["refrigerate", "Ice"],
+  ["aerilate", "Flying"],
+]);
+
+/**
+ * 攻撃技のタイプに対して、攻撃側の特性によるタイプ変更を適用する。
+ *
+ * ノーマル技 × タイプ変更系特性の組み合わせのときだけ変換後タイプを返し、
+ * それ以外は `originalMoveType` をそのまま返す（regression-free）。
+ *
+ * @param originalMoveType 技本来のタイプ
+ * @param moveCategory 技カテゴリ（Status は変換対象外）
+ * @param abilityId 特性 ID（正規化済み、未指定・不明な特性は変換しない）
+ */
+export function applyOffensiveTypeOverride(
+  originalMoveType: TypeName,
+  moveCategory: OffensiveMoveCategory,
+  abilityId: string | undefined,
+): TypeName {
+  if (abilityId === undefined) {
+    return originalMoveType;
+  }
+  if (originalMoveType !== NORMAL_TYPE) {
+    return originalMoveType;
+  }
+  if (moveCategory === STATUS_CATEGORY) {
+    return originalMoveType;
+  }
+  const overrideType = OFFENSIVE_TYPE_OVERRIDES.get(abilityId);
+  if (overrideType === undefined) {
+    return originalMoveType;
+  }
+  return overrideType;
+}

--- a/shared/src/analysis/offensive-ability-overrides.ts
+++ b/shared/src/analysis/offensive-ability-overrides.ts
@@ -21,13 +21,16 @@ const STATUS_CATEGORY = "Status" as const;
 /** 本モジュールが受け付ける技カテゴリ */
 export type OffensiveMoveCategory = "Physical" | "Special" | "Status";
 
+/** 文字列を ID 相当（英数字のみ・小文字）に正規化する */
+function toId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 /**
  * 特性 ID → 変換後タイプのマップ。
- * キーは `toID` 相当で正規化済みの特性 ID（例: "pixilate"）。
+ * キーは `toId` 相当で正規化済みの特性 ID（例: "pixilate"）。
  *
- * `data/champions/abilities.json` の id と一致する。呼び出し側は
- * 日本語特性名を `abilityNameResolver.toEnglish` → `toDataId` の順で
- * 正規化してから渡す責務を持つ。
+ * `data/champions/abilities.json` の id と一致する。
  */
 export const OFFENSIVE_TYPE_OVERRIDES: ReadonlyMap<string, TypeName> = new Map([
   ["pixilate", "Fairy"],
@@ -42,16 +45,20 @@ export const OFFENSIVE_TYPE_OVERRIDES: ReadonlyMap<string, TypeName> = new Map([
  * ノーマル技 × タイプ変更系特性の組み合わせのときだけ変換後タイプを返し、
  * それ以外は `originalMoveType` をそのまま返す（regression-free）。
  *
+ * ability は英語名（@smogon/calc 互換の "Pixilate" 等）または ID
+ * （"pixilate" 等）を受け付ける。内部で `toId` による正規化を行う。
+ * 未知の値はそのまま無視する。
+ *
  * @param originalMoveType 技本来のタイプ
  * @param moveCategory 技カテゴリ（Status は変換対象外）
- * @param abilityId 特性 ID（正規化済み、未指定・不明な特性は変換しない）
+ * @param ability 特性名（英語名 or ID、未指定・不明な特性は変換しない）
  */
 export function applyOffensiveTypeOverride(
   originalMoveType: TypeName,
   moveCategory: OffensiveMoveCategory,
-  abilityId: string | undefined,
+  ability: string | undefined,
 ): TypeName {
-  if (abilityId === undefined) {
+  if (ability === undefined) {
     return originalMoveType;
   }
   if (originalMoveType !== NORMAL_TYPE) {
@@ -60,6 +67,7 @@ export function applyOffensiveTypeOverride(
   if (moveCategory === STATUS_CATEGORY) {
     return originalMoveType;
   }
+  const abilityId = toId(ability);
   const overrideType = OFFENSIVE_TYPE_OVERRIDES.get(abilityId);
   if (overrideType === undefined) {
     return originalMoveType;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,6 +6,7 @@ export * from "./analysis/stat-calculator";
 export * from "./analysis/speed-comparator";
 export * from "./analysis/priority-moves";
 export * from "./analysis/defensive-ability-overrides";
+export * from "./analysis/offensive-ability-overrides";
 export * from "./schemas/pokemon-input";
 export * from "./schemas/stats";
 export type {


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/ai-rotom/issues/27

`analyze_party_coverage` が `pokemonSchema.ability` を無視していた問題を解消し、
タイプ変更系特性（Pixilate / Galvanize / Refrigerate / Aerilate）が
ノーマル技を対応タイプに変換することをカバレッジ計算に反映する。

## Changes

* `shared/src/analysis/offensive-ability-overrides.ts` を新規追加
  * `applyOffensiveTypeOverride(originalMoveType, moveCategory, abilityId)` 純関数
  * `OFFENSIVE_TYPE_OVERRIDES` マップ（`pixilate→Fairy` / `galvanize→Electric` / `refrigerate→Ice` / `aerilate→Flying`）
  * ランタイム依存ゼロ方針を維持（`TypeName` 型のみ import）
* `shared/src/index.ts` で新規モジュールを re-export
* `packages/mcp-server/src/tools/analysis/party-coverage.ts` を更新
  * `abilityNameResolver` で特性名（日英）を ID に正規化するヘルパー `resolveAbilityId` を追加
  * `attackingTypes` の集計と 18 タイプ走査の両方で effectiveType ベースに変更
  * `BestAttackerEntry` に optional `effectiveType` を追加（元タイプと異なる場合のみ設定）
  * 未知の特性文字列は silent fallback（エラーにせず元タイプ維持）
* テスト追加
  * `shared/src/analysis/offensive-ability-overrides.test.ts`: 4 特性 × ノーマル/非ノーマル/status/未知特性/undefined のマトリクス
  * `party-coverage.test.ts`: Pixilate + Hyper Beam → Fairy / Galvanize + Body Slam → Electric / 非ノーマル技スルー / 特性なし regression / 未知特性 fallback

## Checklist

- [x] `npm test` 全 298 件 PASS
- [x] `npm run build` 成功
- [x] `tsc --noEmit` 型エラーなし
- [x] `scripts/verify-dist-bundle.sh` PASS
- [x] 既存出力への後方互換性を維持（`effectiveType` は optional の追加フィールド）

## その他

威力補正（1.2 倍）は本ツールがタイプ相性のみを扱うためスコープ外。将来
`analyze_matchup` / `find_counters` 側で再利用できるよう shared に配置した。
防御側特性（ふゆう等）や複合タイプ対応は本 issue のスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)