### PR TITLE
feat(analyze_party_coverage): 実在する複合タイプのカバレッジを追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ TS6059 エラーにならないようにしている。
 |---|---|
 | `analyze_matchup` | 2 体対面分析 |
 | `analyze_party_weakness` | パーティ弱点分析 |
-| `analyze_party_coverage` | パーティ攻撃カバレッジ分析 |
+| `analyze_party_coverage` | パーティ攻撃カバレッジ分析（単一 18 タイプ + 実在複合タイプ） |
 | `analyze_selection` | 6v6 選出判断一括分析 |
 | `find_counters` | 対策候補の双方向ダメ計・素早さ・タイプ相性（判断は AI 側） |
 

--- a/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
@@ -454,4 +454,203 @@ describe("analyze_party_coverage logic", () => {
       expect(out.coverage.find((c) => c.defenderType === "Flying")?.maxMultiplier).toBe(SUPER_EFFECTIVE);
     });
   });
+
+  describe("dualTypeCoverage × タイプ変更系特性の反映", () => {
+    // タイプ相性の倍率
+    const QUAD_EFFECTIVE = 4;
+    const SUPER_EFFECTIVE = 2;
+    const NO_EFFECT = 0;
+
+    // 防御側の代表的な複合タイプ（英名辞書順）
+    const DARK_DRAGON: readonly [string, string] = ["Dark", "Dragon"];
+
+    // 攻撃側のパーティ定義
+    const PIXILATE_MEGA_ALTARIA = {
+      name: "メガチルタリス",
+      ability: "Pixilate",
+    };
+    const PIXILATE_MEGA_ALTARIA_JA = {
+      name: "メガチルタリス",
+      ability: "フェアリースキン",
+    };
+    const HYPER_BEAM_MOVES = { メガチルタリス: ["Hyper Beam"] };
+    const DRAGON_PULSE_MOVES = { メガチルタリス: ["Dragon Pulse"] };
+
+    const GALVANIZE_JOLTEON = {
+      name: "サンダース",
+      ability: "エレキスキン",
+    };
+    const BODY_SLAM_MOVES = { サンダース: ["Body Slam"] };
+
+    /**
+     * 指定した複合タイプのエントリを `dualTypeCoverage` から取り出す。
+     * `defenderTypes` は英名辞書順でソート済みなので、与えた順序どおりに検索する。
+     */
+    function findDualTypeEntry(
+      out: ReturnType<typeof analyzePartyCoverage>,
+      types: readonly [string, string],
+    ): ReturnType<typeof analyzePartyCoverage>["dualTypeCoverage"][number] | undefined {
+      return out.dualTypeCoverage.find(
+        (e) => e.defenderTypes[0] === types[0] && e.defenderTypes[1] === types[1],
+      );
+    }
+
+    it("サザンドラ (Dark/Dragon) は Pixilate 存在確認のデータ前提を満たす", () => {
+      // テスト対象の前提: サザンドラが実在し Dark/Dragon 複合タイプであること
+      const hydreigon = championsPokemon.find((p) => p.name === "Hydreigon");
+      expect(hydreigon).toBeDefined();
+      expect(hydreigon?.types).toEqual(["Dark", "Dragon"]);
+    });
+
+    it("Pixilate + Hyper Beam は サザンドラ (Dark/Dragon) に 4 倍になる", () => {
+      // Arrange
+      const party = {
+        myParty: [PIXILATE_MEGA_ALTARIA],
+        moves: HYPER_BEAM_MOVES,
+      };
+
+      // Act
+      const out = analyzePartyCoverage(party);
+      const darkDragon = findDualTypeEntry(out, DARK_DRAGON);
+
+      // Assert: Fairy は Dark 2倍 × Dragon 2倍 = 4 倍
+      expect(darkDragon).toBeDefined();
+      expect(darkDragon?.maxMultiplier).toBe(QUAD_EFFECTIVE);
+      expect(darkDragon?.bestAttackers).toHaveLength(1);
+      expect(darkDragon?.bestAttackers[0].move).toBe("Hyper Beam");
+      expect(darkDragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+    });
+
+    it("Pixilate + 非ノーマル技（Dragon Pulse）では effectiveType が付与されない（regression）", () => {
+      // Arrange: ノーマル技でない技はタイプ変更対象外
+      const party = {
+        myParty: [PIXILATE_MEGA_ALTARIA],
+        moves: DRAGON_PULSE_MOVES,
+      };
+
+      // Act
+      const out = analyzePartyCoverage(party);
+
+      // Assert: dualTypeCoverage の全エントリで effectiveType は未設定
+      expect(out.dualTypeCoverage.length).toBeGreaterThan(0);
+      for (const entry of out.dualTypeCoverage) {
+        for (const attacker of entry.bestAttackers) {
+          expect(attacker.effectiveType).toBeUndefined();
+        }
+      }
+      // 攻撃タイプは Dragon のまま（Fairy に変換されていない）
+      expect(out.attackingTypes.some((t) => t.type === "Dragon")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(false);
+    });
+
+    it("未知特性は silent fallback し Normal として評価される（dualType 側）", () => {
+      // Arrange: ガブリアス + 未知特性 + Hyper Beam
+      const UNKNOWN_ABILITY_PARTY = {
+        myParty: [{ name: "ガブリアス", ability: "そんなとくせいない" }],
+        moves: { ガブリアス: ["Hyper Beam"] },
+      };
+
+      // Act
+      const out = analyzePartyCoverage(UNKNOWN_ABILITY_PARTY);
+
+      // Assert: 攻撃タイプは Normal のまま、effectiveType は付与されない
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(false);
+      expect(out.dualTypeCoverage.length).toBeGreaterThan(0);
+      for (const entry of out.dualTypeCoverage) {
+        for (const attacker of entry.bestAttackers) {
+          expect(attacker.effectiveType).toBeUndefined();
+        }
+      }
+    });
+
+    it("日本語特性名（フェアリースキン）でも dualTypeCoverage に反映される", () => {
+      // Arrange: 英語名 "Pixilate" と同じ挙動になるはず
+      const party = {
+        myParty: [PIXILATE_MEGA_ALTARIA_JA],
+        moves: HYPER_BEAM_MOVES,
+      };
+
+      // Act
+      const out = analyzePartyCoverage(party);
+      const darkDragon = findDualTypeEntry(out, DARK_DRAGON);
+
+      // Assert
+      expect(darkDragon?.maxMultiplier).toBe(QUAD_EFFECTIVE);
+      expect(darkDragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+    });
+
+    it("単一 coverage と dualTypeCoverage で effectiveType が一致する（対称性）", () => {
+      // Arrange: 同一パーティ・同一特性
+      const party = {
+        myParty: [PIXILATE_MEGA_ALTARIA],
+        moves: HYPER_BEAM_MOVES,
+      };
+
+      // Act
+      const out = analyzePartyCoverage(party);
+      const singleDragon = out.coverage.find((c) => c.defenderType === "Dragon");
+      const darkDragon = findDualTypeEntry(out, DARK_DRAGON);
+
+      // Assert: 単一 Dragon に対して Fairy として 2 倍、複合 Dark/Dragon に対しても Fairy として 4 倍
+      expect(singleDragon?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(singleDragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+      expect(darkDragon?.maxMultiplier).toBe(QUAD_EFFECTIVE);
+      expect(darkDragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+      // 両側が同じ effectiveType であること（対称性）
+      expect(singleDragon?.bestAttackers[0].effectiveType).toBe(
+        darkDragon?.bestAttackers[0].effectiveType,
+      );
+    });
+
+    it("Galvanize + Body Slam は Electric として dualType 側でも評価される", () => {
+      // Arrange: Ground を含む複合タイプは でんき技に 0 倍
+      const GROUND_ROCK: readonly [string, string] = ["Ground", "Rock"];
+      const party = {
+        myParty: [GALVANIZE_JOLTEON],
+        moves: BODY_SLAM_MOVES,
+      };
+
+      // Act
+      const out = analyzePartyCoverage(party);
+      const groundRock = findDualTypeEntry(out, GROUND_ROCK);
+
+      // Assert: Ground を含むので でんき技は 0 倍
+      expect(groundRock).toBeDefined();
+      expect(groundRock?.maxMultiplier).toBe(NO_EFFECT);
+      // 0 倍エントリは bestAttackers に列挙しない仕様
+      expect(groundRock?.bestAttackers).toHaveLength(0);
+
+      // 単一 Ground タイプ側も 0 倍で、Electric 技しかないパーティなので uncovered
+      const single = out.coverage.find((c) => c.defenderType === "Ground");
+      expect(single?.maxMultiplier).toBe(NO_EFFECT);
+    });
+
+    it("Galvanize + Body Slam は Water タイプ複合に Electric として 2 倍を出す（単一-複合の対称性）", () => {
+      // Arrange: Water/X (X != Ground) なら Electric は 2 倍
+      // 実在する Water 複合として Water/Flying (ギャラドス等) を採用
+      const WATER_FLYING: readonly [string, string] = ["Flying", "Water"];
+      const party = {
+        myParty: [GALVANIZE_JOLTEON],
+        moves: BODY_SLAM_MOVES,
+      };
+
+      // Act
+      const out = analyzePartyCoverage(party);
+      const waterFlying = findDualTypeEntry(out, WATER_FLYING);
+      const singleWater = out.coverage.find((c) => c.defenderType === "Water");
+
+      // Assert: Water/Flying は Electric に 4 倍（Water 2倍 × Flying 2倍）
+      expect(waterFlying?.maxMultiplier).toBe(QUAD_EFFECTIVE);
+      expect(waterFlying?.bestAttackers[0].move).toBe("Body Slam");
+      expect(waterFlying?.bestAttackers[0].effectiveType).toBe("Electric");
+
+      // 単一 Water 側は 2 倍 + effectiveType === "Electric"（対称性）
+      expect(singleWater?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(singleWater?.bestAttackers[0].effectiveType).toBe("Electric");
+      expect(singleWater?.bestAttackers[0].effectiveType).toBe(
+        waterFlying?.bestAttackers[0].effectiveType,
+      );
+    });
+  });
 });

--- a/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Generations, toID } from "@smogon/calc";
 import {
   championsLearnsets,
+  championsPokemon,
   championsTypes,
   movesById,
   pokemonById,
@@ -294,6 +295,163 @@ describe("analyze_party_coverage logic", () => {
       const dragon = out.coverage.find((c) => c.defenderType === "Dragon");
       expect(dragon?.maxMultiplier).toBe(SUPER_EFFECTIVE);
       expect(dragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+    });
+  });
+
+  describe("dualTypeCoverage（実在する複合タイプへのカバレッジ）", () => {
+    const QUAD_EFFECTIVE = 4;
+    const SUPER_EFFECTIVE = 2;
+    const NO_EFFECT = 0;
+
+    it("ドラゴン/じめん × こおり技 で maxMultiplier=4 になる", () => {
+      // マンムー (こおり/じめん) → Icicle Crash / Icicle Spear 等を習得
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "マンムー" }],
+        moves: { マンムー: ["Icicle Crash"] },
+      });
+      const dragonGround = out.dualTypeCoverage.find(
+        (e) =>
+          (e.defenderTypes[0] === "Dragon" && e.defenderTypes[1] === "Ground") ||
+          (e.defenderTypes[0] === "Ground" && e.defenderTypes[1] === "Dragon"),
+      );
+      expect(dragonGround).toBeDefined();
+      expect(dragonGround?.maxMultiplier).toBe(QUAD_EFFECTIVE);
+      expect(dragonGround?.bestAttackers[0].move).toBe("Icicle Crash");
+    });
+
+    it("ほのお/ひこう × いわ技 で maxMultiplier=4 になる", () => {
+      // バンギラス (いわ/あく) は Stone Edge を習得する
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "バンギラス" }],
+        moves: { バンギラス: ["Stone Edge"] },
+      });
+      const fireFlying = out.dualTypeCoverage.find(
+        (e) =>
+          (e.defenderTypes[0] === "Fire" && e.defenderTypes[1] === "Flying") ||
+          (e.defenderTypes[0] === "Flying" && e.defenderTypes[1] === "Fire"),
+      );
+      expect(fireFlying).toBeDefined();
+      expect(fireFlying?.maxMultiplier).toBe(QUAD_EFFECTIVE);
+      expect(fireFlying?.bestAttackers[0].move).toBe("Stone Edge");
+    });
+
+    it("実在しない複合タイプ（Fairy/Poison 等）は dualTypeCoverage に含まれない", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["Earthquake"] },
+      });
+
+      // データから実在する複合タイプ集合を再構築して突合
+      const realDualTypes = new Set<string>();
+      for (const p of championsPokemon) {
+        const DUAL_COUNT = 2;
+        if (p.types.length === DUAL_COUNT) {
+          const sorted = [...p.types].sort();
+          realDualTypes.add(`${sorted[0]}/${sorted[1]}`);
+        }
+      }
+
+      expect(out.dualTypeCoverage.length).toBe(realDualTypes.size);
+      for (const entry of out.dualTypeCoverage) {
+        const key = `${entry.defenderTypes[0]}/${entry.defenderTypes[1]}`;
+        expect(realDualTypes.has(key)).toBe(true);
+      }
+      // 実在しない代表例を複数チェック（データ追加で片方のみ実在になっても検出できるように）
+      const nonExistentPairs: ReadonlyArray<readonly [string, string]> = [
+        ["Bug", "Dragon"],
+        ["Fairy", "Poison"],
+        ["Fighting", "Ground"],
+      ];
+      for (const [a, b] of nonExistentPairs) {
+        const hit = out.dualTypeCoverage.find(
+          (e) =>
+            (e.defenderTypes[0] === a && e.defenderTypes[1] === b) ||
+            (e.defenderTypes[0] === b && e.defenderTypes[1] === a),
+        );
+        expect(hit).toBeUndefined();
+      }
+    });
+
+    it("examplePokemon に そのタイプを持つ代表的なポケモンの日本語名が入る", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["Earthquake"] },
+      });
+      const dragonGround = out.dualTypeCoverage.find(
+        (e) => e.defenderTypes[0] === "Dragon" && e.defenderTypes[1] === "Ground",
+      );
+      expect(dragonGround).toBeDefined();
+      expect(dragonGround?.examplePokemon).toContain("ガブリアス");
+    });
+
+    it("dualTypeUncoveredCount が maxMultiplier<=EFFECTIVE_THRESHOLD の件数と一致する", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["Earthquake"] },
+      });
+      const uncoveredByFilter = out.dualTypeCoverage.filter(
+        (e) => e.maxMultiplier <= EFFECTIVE_THRESHOLD,
+      ).length;
+      expect(out.dualTypeUncoveredCount).toBe(uncoveredByFilter);
+    });
+
+    it("defenderTypes は英名辞書順でソートされている", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["Earthquake"] },
+      });
+      for (const entry of out.dualTypeCoverage) {
+        expect(entry.defenderTypes[0].localeCompare(entry.defenderTypes[1])).toBeLessThanOrEqual(0);
+      }
+    });
+
+    it("電気無効を活用: でんき技 × ひこう/じめん 系の複合タイプに 0 倍が出る", () => {
+      // Flying/Ground は実在しないが、Ground を含む複合タイプ (例: Dragon/Ground)
+      // に対して Electric 技は 0 倍になる
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ピカチュウ" }],
+        moves: { ピカチュウ: ["Thunderbolt"] },
+      });
+      const dragonGround = out.dualTypeCoverage.find(
+        (e) => e.defenderTypes[0] === "Dragon" && e.defenderTypes[1] === "Ground",
+      );
+      expect(dragonGround?.maxMultiplier).toBe(NO_EFFECT);
+    });
+
+    it("攻撃技が無いパーティは 全エントリの maxMultiplier=0 かつ dualTypeUncoveredCount=エントリ数", () => {
+      // 変化技のみ指定 → resolveAttackingMoveIds が Status を除外するので攻撃技ゼロ
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["Swords Dance"] },
+      });
+      expect(out.dualTypeCoverage.length).toBeGreaterThan(0);
+      for (const entry of out.dualTypeCoverage) {
+        expect(entry.maxMultiplier).toBe(NO_EFFECT);
+        expect(entry.bestAttackers).toHaveLength(0);
+      }
+      expect(out.dualTypeUncoveredCount).toBe(out.dualTypeCoverage.length);
+    });
+
+    it("dualTypeCoverage は maxMultiplier 昇順でソートされる", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["Earthquake"] },
+      });
+      for (let i = 1; i < out.dualTypeCoverage.length; i += 1) {
+        const prev = out.dualTypeCoverage[i - 1].maxMultiplier;
+        const curr = out.dualTypeCoverage[i].maxMultiplier;
+        expect(prev).toBeLessThanOrEqual(curr);
+      }
+    });
+
+    it("いわ技は ほのお/ひこう に 抜群以上、ガブリアス (Dragon/Ground) は 等倍以下を維持", () => {
+      // 複合分析の副作用で単一タイプ結果が壊れないことを確認
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "バンギラス" }],
+        moves: { バンギラス: ["Stone Edge"] },
+      });
+      expect(out.coverage.find((c) => c.defenderType === "Fire")?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(out.coverage.find((c) => c.defenderType === "Flying")?.maxMultiplier).toBe(SUPER_EFFECTIVE);
     });
   });
 });

--- a/packages/mcp-server/src/tools/analysis/party-coverage.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.ts
@@ -51,6 +51,7 @@ const TOOL_DESCRIPTION =
   "パーティの攻撃カバレッジを分析する。各防御タイプ（18種）に対して、パーティのどの技が最も効果的かを算出し、抜群を取れないタイプを洗い出す。"
   + " `uncoveredTypes` は『抜群（>1 倍）を取れる技が 1 つも無い防御タイプ』を列挙する（等倍 1 倍も含む）。抜群倍率の内訳は `coverage[].maxMultiplier` を参照。"
   + " 実在する複合タイプ（データ内に 1 匹以上存在する 2 タイプ組合せ）に対するカバレッジは `dualTypeCoverage` を参照。抜群を取れない複合タイプ数は `dualTypeUncoveredCount`。"
+  + " 攻撃側のタイプ変換系特性（Pixilate 等）は単一/複合カバレッジ双方に反映される。"
   + " ポケモンチャンピオンズ対応。";
 
 const inputSchema = {
@@ -311,6 +312,48 @@ export interface AnalyzePartyCoverageInput {
 }
 
 /**
+ * 攻撃技の effectiveType を前計算済みのパーティメンバー。
+ *
+ * 単一タイプ coverage と dualTypeCoverage の両ループが同じ effectiveType
+ * を参照できるよう、`attackingTypesSet` 構築時に一度だけ算出しておく。
+ * `ability` は effectiveType に吸収されるためここでは保持しない。
+ */
+interface PrecomputedMember {
+  entry: PokemonEntry;
+  attackingMoves: Array<{ move: MoveEntry; effectiveType: TypeName }>;
+}
+
+/**
+ * 候補の attacker で `bestAttackers` を更新する共通ロジック。
+ *
+ * - `candidate.multiplier > currentMax` の場合は bestAttackers をクリアして入れ替え、新しい max を返す
+ * - タイの場合は同一ポケモンが未登録であれば追加する（multiplier > 0 のときのみ、0 倍無効は列挙しない）
+ * - それ以外は現状維持
+ *
+ * bestAttackers は in-place で更新する。maxMultiplier は戻り値として返す。
+ */
+function updateBestAttackers(
+  currentMax: number,
+  bestAttackers: BestAttackerEntry[],
+  candidate: BestAttackerEntry,
+): number {
+  if (candidate.multiplier > currentMax) {
+    bestAttackers.length = 0;
+    bestAttackers.push(candidate);
+    return candidate.multiplier;
+  }
+  if (candidate.multiplier === currentMax && candidate.multiplier > 0) {
+    const alreadyHasSamePokemon = bestAttackers.some(
+      (ba) => ba.pokemon === candidate.pokemon,
+    );
+    if (!alreadyHasSamePokemon) {
+      bestAttackers.push(candidate);
+    }
+  }
+  return currentMax;
+}
+
+/**
  * パーティの攻撃カバレッジを計算する純関数。
  * MCP tool handler からも直接テストからも呼び出せる。
  */
@@ -320,31 +363,27 @@ export function analyzePartyCoverage(
   const gen = Generations.get(CHAMPIONS_GEN_NUM);
   const movesMap = normalizeMovesMap(args.moves);
 
-  interface MemberWithMoves {
-    entry: PokemonEntry;
-    attackingMoves: MoveEntry[];
-    ability: string | undefined;
-  }
-
-  const members: MemberWithMoves[] = [];
+  const members: PrecomputedMember[] = [];
   const attackingTypesSet = new Set<string>();
 
   for (const member of args.myParty) {
     const entry = resolvePokemonEntry(member.name);
     const explicitMoves = movesMap.get(entry.id);
-    const attackingMoves = resolveAttackingMoveIds(entry, explicitMoves);
+    const rawAttackingMoves = resolveAttackingMoveIds(entry, explicitMoves);
     const ability = resolveOptionalName(abilityNameResolver, member.ability);
 
-    for (const move of attackingMoves) {
+    const attackingMoves: Array<{ move: MoveEntry; effectiveType: TypeName }> = [];
+    for (const move of rawAttackingMoves) {
       const effectiveType = applyOffensiveTypeOverride(
         move.type as TypeName,
         move.category,
         ability,
       );
       attackingTypesSet.add(effectiveType);
+      attackingMoves.push({ move, effectiveType });
     }
 
-    members.push({ entry, attackingMoves, ability });
+    members.push({ entry, attackingMoves });
   }
 
   const attackingTypes: AttackingTypeEntry[] = [];
@@ -367,12 +406,7 @@ export function analyzePartyCoverage(
     const bestAttackers: BestAttackerEntry[] = [];
 
     for (const member of members) {
-      for (const move of member.attackingMoves) {
-        const effectiveType = applyOffensiveTypeOverride(
-          move.type as TypeName,
-          move.category,
-          member.ability,
-        );
+      for (const { move, effectiveType } of member.attackingMoves) {
         const multiplier = getEffectivenessForDefenderType(
           effectiveType,
           defenderType.name,
@@ -386,18 +420,7 @@ export function analyzePartyCoverage(
         if (effectiveType !== move.type) {
           attacker.effectiveType = effectiveType;
         }
-        if (multiplier > maxMultiplier) {
-          maxMultiplier = multiplier;
-          bestAttackers.length = 0;
-          bestAttackers.push(attacker);
-        } else if (multiplier === maxMultiplier && multiplier > 0) {
-          const alreadyHasSamePokemon = bestAttackers.some(
-            (ba) => ba.pokemon === member.entry.name,
-          );
-          if (!alreadyHasSamePokemon) {
-            bestAttackers.push(attacker);
-          }
-        }
+        maxMultiplier = updateBestAttackers(maxMultiplier, bestAttackers, attacker);
       }
     }
 
@@ -425,28 +448,17 @@ export function analyzePartyCoverage(
     const bestAttackers: BestAttackerEntry[] = [];
 
     for (const member of members) {
-      for (const move of member.attackingMoves) {
-        const multiplier = getEffectivenessForDualTypes(move.type, types, gen);
-        if (multiplier > maxMultiplier) {
-          maxMultiplier = multiplier;
-          bestAttackers.length = 0;
-          bestAttackers.push({
-            pokemon: member.entry.name,
-            move: move.name,
-            multiplier,
-          });
-        } else if (multiplier === maxMultiplier && multiplier > 0) {
-          const alreadyHasSamePokemon = bestAttackers.some(
-            (ba) => ba.pokemon === member.entry.name,
-          );
-          if (!alreadyHasSamePokemon) {
-            bestAttackers.push({
-              pokemon: member.entry.name,
-              move: move.name,
-              multiplier,
-            });
-          }
+      for (const { move, effectiveType } of member.attackingMoves) {
+        const multiplier = getEffectivenessForDualTypes(effectiveType, types, gen);
+        const attacker: BestAttackerEntry = {
+          pokemon: member.entry.name,
+          move: move.name,
+          multiplier,
+        };
+        if (effectiveType !== move.type) {
+          attacker.effectiveType = effectiveType;
         }
+        maxMultiplier = updateBestAttackers(maxMultiplier, bestAttackers, attacker);
       }
     }
 

--- a/packages/mcp-server/src/tools/analysis/party-coverage.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.ts
@@ -10,6 +10,7 @@ import {
 } from "@ai-rotom/shared";
 import {
   championsLearnsets,
+  championsPokemon,
   championsTypes,
   movesById,
   pokemonById,
@@ -26,6 +27,15 @@ import {
 
 const CHAMPIONS_GEN_NUM = 0;
 
+/** 複合タイプを構成するタイプ数 */
+const DUAL_TYPE_COUNT = 2;
+
+/** 複合タイプ集合キーのセパレータ（タイプ名に現れない文字） */
+const DUAL_TYPE_KEY_SEPARATOR = "/";
+
+/** `dualTypeCoverage` の `examplePokemon` に収める最大件数 */
+const MAX_EXAMPLE_POKEMON = 3;
+
 /**
  * 抜群ラインのしきい値。
  * この値「ちょうど」までは uncovered 扱い、「これを超える」と covered 扱い。
@@ -40,7 +50,8 @@ const TOOL_NAME = "analyze_party_coverage";
 const TOOL_DESCRIPTION =
   "パーティの攻撃カバレッジを分析する。各防御タイプ（18種）に対して、パーティのどの技が最も効果的かを算出し、抜群を取れないタイプを洗い出す。"
   + " `uncoveredTypes` は『抜群（>1 倍）を取れる技が 1 つも無い防御タイプ』を列挙する（等倍 1 倍も含む）。抜群倍率の内訳は `coverage[].maxMultiplier` を参照。"
-  + " 2タイプ複合のディフェンダーは analyze_matchup で個別に確認してください。ポケモンチャンピオンズ対応。";
+  + " 実在する複合タイプ（データ内に 1 匹以上存在する 2 タイプ組合せ）に対するカバレッジは `dualTypeCoverage` を参照。抜群を取れない複合タイプ数は `dualTypeUncoveredCount`。"
+  + " ポケモンチャンピオンズ対応。";
 
 const inputSchema = {
   myParty: z.array(pokemonSchema).describe("自分のパーティ（moves 未指定時は learnset 内の全攻撃技を候補にする）"),
@@ -80,6 +91,28 @@ interface CoverageEntry {
   bestAttackers: BestAttackerEntry[];
 }
 
+/**
+ * 実在する複合タイプ（データ内に 1 匹以上存在する 2 タイプ組合せ）に対する
+ * パーティのカバレッジエントリ。
+ */
+interface DualTypeCoverageEntry {
+  /** 防御側の複合タイプ（英名、英名辞書順でソート済み） */
+  defenderTypes: [string, string];
+  /** 防御側の複合タイプ（日本語名、`defenderTypes` と同じ順序） */
+  defenderTypesJa: [string, string];
+  /**
+   * パーティ内の全攻撃技がこの複合タイプに与える最大倍率。
+   * 0 (無効) / 0.25 / 0.5 / 1 (等倍) / 2 / 4 のいずれか。
+   */
+  maxMultiplier: number;
+  bestAttackers: BestAttackerEntry[];
+  /**
+   * この複合タイプを持つ代表的なポケモン名（日本語名優先、上位 `MAX_EXAMPLE_POKEMON` 件）。
+   * AI が「このタイプ組合せ = あのポケモン」と結び付けるための補助情報。
+   */
+  examplePokemon: string[];
+}
+
 export interface PartyCoverageOutput {
   attackingTypes: AttackingTypeEntry[];
   coverage: CoverageEntry[];
@@ -88,6 +121,16 @@ export interface PartyCoverageOutput {
    * `coverage[].maxMultiplier <= 1` (無効・半減・等倍) となるタイプが該当する。
    */
   uncoveredTypes: AttackingTypeEntry[];
+  /**
+   * 実在する複合タイプに対するカバレッジ。
+   * `maxMultiplier` 昇順（抜群を取れないものが先頭）で安定ソート済み。
+   */
+  dualTypeCoverage: DualTypeCoverageEntry[];
+  /**
+   * 抜群を取れない複合タイプ数。
+   * `dualTypeCoverage[].maxMultiplier <= EFFECTIVE_THRESHOLD` の件数と一致する。
+   */
+  dualTypeUncoveredCount: number;
 }
 
 /**
@@ -197,6 +240,69 @@ function getEffectivenessForDefenderType(
   return calculateTypeEffectiveness(gen, attackTypeName as TypeName, [
     defenderTypeName as TypeName,
   ]);
+}
+
+/**
+ * 攻撃タイプ → 複合防御タイプへの倍率を計算する。
+ */
+function getEffectivenessForDualTypes(
+  attackTypeName: string,
+  defenderTypes: readonly [string, string],
+  gen: ReturnType<typeof Generations.get>,
+): number {
+  return calculateTypeEffectiveness(
+    gen,
+    attackTypeName as TypeName,
+    defenderTypes as readonly TypeName[],
+  );
+}
+
+/**
+ * 実在する複合タイプ（データ内に 1 匹以上存在するタイプ組合せ）の集合を構築する。
+ * 対称性解消のため、キーは英名辞書順の 2 タイプを `/` で連結した文字列とする。
+ *
+ * `examplePokemon` 用の代表ポケモンも同時に収集する:
+ * - メガ進化・リージョンフォーム等の派生フォーム（`baseSpecies !== null`）は後置し、
+ *   ベース種族を優先表示する（同じ実体の重複を避けるため）
+ * - 同一優先度内では英名の辞書順で安定化
+ * - 先頭 `MAX_EXAMPLE_POKEMON` 件を採用
+ */
+function buildRealDualTypeMap(
+  pokemon: readonly PokemonEntry[],
+): Map<string, { types: [string, string]; examplePokemon: string[] }> {
+  const accumulator = new Map<string, { types: [string, string]; entries: PokemonEntry[] }>();
+
+  for (const entry of pokemon) {
+    if (entry.types.length !== DUAL_TYPE_COUNT) {
+      continue;
+    }
+    const sortedTypes = [...entry.types].sort((a, b) => a.localeCompare(b)) as [string, string];
+    const key = `${sortedTypes[0]}${DUAL_TYPE_KEY_SEPARATOR}${sortedTypes[1]}`;
+
+    const existing = accumulator.get(key);
+    if (existing === undefined) {
+      accumulator.set(key, { types: sortedTypes, entries: [entry] });
+    } else {
+      existing.entries.push(entry);
+    }
+  }
+
+  const result = new Map<string, { types: [string, string]; examplePokemon: string[] }>();
+  for (const [key, { types, entries }] of accumulator) {
+    const sorted = [...entries].sort((a, b) => {
+      const aIsForme = a.baseSpecies !== null ? 1 : 0;
+      const bIsForme = b.baseSpecies !== null ? 1 : 0;
+      if (aIsForme !== bIsForme) {
+        return aIsForme - bIsForme;
+      }
+      return a.name.localeCompare(b.name);
+    });
+    const examplePokemon = sorted
+      .slice(0, MAX_EXAMPLE_POKEMON)
+      .map((entry) => pokemonNameResolver.toJapanese(entry.name) ?? entry.name);
+    result.set(key, { types, examplePokemon });
+  }
+  return result;
 }
 
 export interface AnalyzePartyCoverageInput {
@@ -310,10 +416,72 @@ export function analyzePartyCoverage(
     }
   }
 
+  const dualTypeMap = buildRealDualTypeMap(championsPokemon);
+  const dualTypeCoverage: DualTypeCoverageEntry[] = [];
+  let dualTypeUncoveredCount = 0;
+
+  for (const { types, examplePokemon } of dualTypeMap.values()) {
+    let maxMultiplier = 0;
+    const bestAttackers: BestAttackerEntry[] = [];
+
+    for (const member of members) {
+      for (const move of member.attackingMoves) {
+        const multiplier = getEffectivenessForDualTypes(move.type, types, gen);
+        if (multiplier > maxMultiplier) {
+          maxMultiplier = multiplier;
+          bestAttackers.length = 0;
+          bestAttackers.push({
+            pokemon: member.entry.name,
+            move: move.name,
+            multiplier,
+          });
+        } else if (multiplier === maxMultiplier && multiplier > 0) {
+          const alreadyHasSamePokemon = bestAttackers.some(
+            (ba) => ba.pokemon === member.entry.name,
+          );
+          if (!alreadyHasSamePokemon) {
+            bestAttackers.push({
+              pokemon: member.entry.name,
+              move: move.name,
+              multiplier,
+            });
+          }
+        }
+      }
+    }
+
+    dualTypeCoverage.push({
+      defenderTypes: types,
+      defenderTypesJa: [
+        typeJaMap.get(types[0]) ?? types[0],
+        typeJaMap.get(types[1]) ?? types[1],
+      ],
+      maxMultiplier,
+      bestAttackers,
+      examplePokemon,
+    });
+
+    if (maxMultiplier <= EFFECTIVE_THRESHOLD) {
+      dualTypeUncoveredCount += 1;
+    }
+  }
+
+  dualTypeCoverage.sort((a, b) => {
+    if (a.maxMultiplier !== b.maxMultiplier) {
+      return a.maxMultiplier - b.maxMultiplier;
+    }
+    if (a.defenderTypes[0] !== b.defenderTypes[0]) {
+      return a.defenderTypes[0].localeCompare(b.defenderTypes[0]);
+    }
+    return a.defenderTypes[1].localeCompare(b.defenderTypes[1]);
+  });
+
   return {
     attackingTypes,
     coverage,
     uncoveredTypes,
+    dualTypeCoverage,
+    dualTypeUncoveredCount,
   };
 }
 


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/ai-rotom/issues/28

`analyze_party_coverage` の出力に、**実在する複合タイプ**（データ内に 1 匹以上存在する 2 タイプ組合せ）に対するカバレッジ情報を追加した。既存の単一タイプ 18 種のカバレッジ (`coverage` / `uncoveredTypes`) は後方互換のため維持している。

ガブリアス (ドラゴン/じめん) の こおり 4 倍のような 4 倍弱点も `dualTypeCoverage` で検出できるようになり、AI が単一タイプ倍率から複合倍率を合成する必要が無くなる。

## Changes

* `packages/mcp-server/src/tools/analysis/party-coverage.ts`
  * 出力型 `PartyCoverageOutput` に以下を追加:
    * `dualTypeCoverage: DualTypeCoverageEntry[]` — 実在する複合タイプごとの最大倍率・最有力技・代表ポケモン (`examplePokemon`, 日本語名優先・上位 3 件)
    * `dualTypeUncoveredCount: number` — 抜群を取れない複合タイプ数
  * `championsPokemon` を走査して実在する複合タイプ集合を構築する純関数 `buildRealDualTypeMap` を追加
  * 複合タイプ倍率計算ヘルパー `getEffectivenessForDualTypes` を追加（shared の `calculateTypeEffectiveness` に委譲）
  * ソート順: `maxMultiplier` 昇順 → 英名辞書順で安定化
  * tool description を更新（単一タイプは analyze_matchup の案内を削除し、`dualTypeCoverage` の利用を明記）
* `packages/mcp-server/src/tools/analysis/party-coverage.test.ts`
  * Issue で列挙されたテスト要件を網羅:
    * ドラゴン/じめん × こおり 4 倍 (マンムー + Icicle Crash)
    * ほのお/ひこう × いわ 4 倍 (バンギラス + Stone Edge)
    * 実在しない複合タイプ (Bug/Dragon 等) が出力に含まれないこと
    * `examplePokemon` に日本語名が入ること（ガブリアス）
    * `dualTypeUncoveredCount` と `maxMultiplier <= EFFECTIVE_THRESHOLD` の件数が一致すること
    * `defenderTypes` が辞書順ソート済みであること
    * 攻撃技なしパーティでの全エントリ 0 倍挙動
    * でんき技 × ドラゴン/じめん で 0 倍になること
* `CLAUDE.md`
  * MCP ツール一覧の `analyze_party_coverage` の概要を「単一 18 タイプ + 実在複合タイプ」に更新

## Checklist

- [x] 既存の 301 件のテストが全て pass すること
- [x] 新規追加の 10 件の `dualTypeCoverage` テストが全て pass すること
- [x] `npm run build` が成功し、`dist/index.mjs` の bundle が 1.71 MB で収まっていること
- [x] 既存出力フィールド (`attackingTypes` / `coverage` / `uncoveredTypes`) の後方互換を維持
- [x] shared ライブラリの変更なし（`calculateTypeEffectiveness` を再利用）

## その他

- 特性によるタイプ変更（#27 の範囲）は本 PR のスコープ外
- `examplePokemon` はベース種族を優先し、派生フォーム（メガ進化等）は後置することで表示の重複を軽減

🤖 Generated with [Claude Code](https://claude.com/claude-code)