### PR TITLE
refactor(mcp-server): selection-analysis を shared learnset フィルタに統一する

### DIFF
--- a/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
+++ b/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Generations, toID } from "@smogon/calc";
-import {
-  DamageCalculatorAdapter,
-  filterResultsByLearnset,
-} from "@ai-rotom/shared";
+import { DamageCalculatorAdapter } from "@ai-rotom/shared";
 import type { DamageCalcResult } from "@ai-rotom/shared";
 import {
   championsLearnsets,
@@ -196,72 +193,6 @@ describe("analyze_selection logic", () => {
       expect(out?.min).toBe(HIGH_MIN);
     });
 
-  });
-
-  describe("getLearnsetMoveIdSet", () => {
-    it("登録済みポケモン (Charizard) は learnset の技 ID を返す", () => {
-      const ids = getLearnsetMoveIdSet(toDataId("Charizard"));
-      expect(ids.size).toBeGreaterThan(0);
-      expect(ids.has("flamethrower")).toBe(true);
-    });
-
-    it("未登録ポケモン ID は空 Set を返す (フォールバック挙動)", () => {
-      const ids = getLearnsetMoveIdSet("nonexistentpokemon");
-      expect(ids.size).toBe(0);
-    });
-  });
-
-  describe("filterResultsByLearnset", () => {
-    const BASE_MIN_PERCENT = 50;
-    const BASE_MAX_PERCENT = 80;
-    const BASE_MIN_DAMAGE = 60;
-    const BASE_MAX_DAMAGE = 90;
-
-    function makeMoveResult(moveName: string): DamageCalcResult {
-      return {
-        attacker: "Charizard",
-        defender: "Garchomp",
-        move: moveName,
-        damage: [BASE_MIN_DAMAGE, BASE_MAX_DAMAGE],
-        min: BASE_MIN_DAMAGE,
-        max: BASE_MAX_DAMAGE,
-        minPercent: BASE_MIN_PERCENT,
-        maxPercent: BASE_MAX_PERCENT,
-        koChance: "test",
-        description: "test",
-        moveType: "Normal",
-        typeMultiplier: 1,
-        isStab: false,
-        effectivePowerMultiplier: 1,
-      };
-    }
-
-    it("learnset に含まれる技のみを残す", () => {
-      const results = [
-        makeMoveResult("Flamethrower"),
-        makeMoveResult("Blizzard"),
-        makeMoveResult("Splash"),
-      ];
-      const learnsetIds = new Set(["flamethrower"]);
-      const filtered = filterResultsByLearnset(results, learnsetIds, toDataId);
-      expect(filtered.map((r) => r.move)).toEqual(["Flamethrower"]);
-    });
-
-    it("learnset が空のときは元の配列をそのまま返す (フォールバック)", () => {
-      const results = [
-        makeMoveResult("Flamethrower"),
-        makeMoveResult("Blizzard"),
-      ];
-      const filtered = filterResultsByLearnset(results, new Set(), toDataId);
-      expect(filtered.map((r) => r.move)).toEqual(["Flamethrower", "Blizzard"]);
-    });
-
-    it("technique 名の大小 / 空白等は toDataId で正規化して一致判定する", () => {
-      const results = [makeMoveResult("Acid Spray")];
-      const learnsetIds = new Set(["acidspray"]);
-      const filtered = filterResultsByLearnset(results, learnsetIds, toDataId);
-      expect(filtered.length).toBe(1);
-    });
   });
 
   describe("calculateDamageForMatchup - learnset filter integration", () => {

--- a/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
+++ b/packages/mcp-server/src/tools/analysis/selection-analysis.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { Generations, toID } from "@smogon/calc";
-import { DamageCalculatorAdapter } from "@ai-rotom/shared";
+import {
+  DamageCalculatorAdapter,
+  filterResultsByLearnset,
+} from "@ai-rotom/shared";
 import type { DamageCalcResult } from "@ai-rotom/shared";
 import {
   championsLearnsets,
+  getLearnsetMoveIdSet,
   pokemonEntryProvider,
   toDataId,
 } from "../../data-store";
@@ -17,8 +21,6 @@ import {
 import {
   bestDamageEstimate,
   calculateDamageForMatchup,
-  filterResultsByLearnset,
-  getLearnsetMoveIdSet,
 } from "./selection-analysis";
 
 const CHAMPIONS_GEN_NUM = 0;
@@ -227,6 +229,10 @@ describe("analyze_selection logic", () => {
         maxPercent: BASE_MAX_PERCENT,
         koChance: "test",
         description: "test",
+        moveType: "Normal",
+        typeMultiplier: 1,
+        isStab: false,
+        effectivePowerMultiplier: 1,
       };
     }
 
@@ -237,7 +243,7 @@ describe("analyze_selection logic", () => {
         makeMoveResult("Splash"),
       ];
       const learnsetIds = new Set(["flamethrower"]);
-      const filtered = filterResultsByLearnset(results, learnsetIds);
+      const filtered = filterResultsByLearnset(results, learnsetIds, toDataId);
       expect(filtered.map((r) => r.move)).toEqual(["Flamethrower"]);
     });
 
@@ -246,14 +252,14 @@ describe("analyze_selection logic", () => {
         makeMoveResult("Flamethrower"),
         makeMoveResult("Blizzard"),
       ];
-      const filtered = filterResultsByLearnset(results, new Set());
+      const filtered = filterResultsByLearnset(results, new Set(), toDataId);
       expect(filtered.map((r) => r.move)).toEqual(["Flamethrower", "Blizzard"]);
     });
 
     it("technique 名の大小 / 空白等は toDataId で正規化して一致判定する", () => {
       const results = [makeMoveResult("Acid Spray")];
       const learnsetIds = new Set(["acidspray"]);
-      const filtered = filterResultsByLearnset(results, learnsetIds);
+      const filtered = filterResultsByLearnset(results, learnsetIds, toDataId);
       expect(filtered.length).toBe(1);
     });
   });

--- a/packages/mcp-server/src/tools/analysis/selection-analysis.ts
+++ b/packages/mcp-server/src/tools/analysis/selection-analysis.ts
@@ -6,13 +6,14 @@ import {
   DamageCalculatorAdapter,
   calculateTypeEffectiveness,
   compareSpeed,
+  filterResultsByLearnset,
   pokemonSchema,
   type BaseStats,
   type DamageCalcResult,
   type SpeedComparison,
 } from "@ai-rotom/shared";
 import {
-  championsLearnsets,
+  getLearnsetMoveIdSet,
   pokemonById,
   pokemonEntryProvider,
   toDataId,
@@ -242,33 +243,6 @@ function resolveMovesMap(
 }
 
 /**
- * 指定ポケモンの learnset に含まれる技 ID セットを取得する。
- * 未登録のポケモンは空 Set を返す。
- * TODO(#13): shared 昇格後は @ai-rotom/shared の共通実装に差し替える。
- */
-export function getLearnsetMoveIdSet(
-  pokemonId: string,
-): ReadonlySet<string> {
-  const learnset = championsLearnsets[pokemonId];
-  if (learnset === undefined) return new Set();
-  return new Set(learnset);
-}
-
-/**
- * calculateAllMoves の結果を attacker の learnset で絞り込む。
- * @smogon/calc は全技を走査するため、実際に覚えない技で過大評価しないようにフィルタする。
- * learnsetMoveIds が空 (= learnset 未登録) の場合はフォールバックで元の配列をそのまま返す。
- * TODO(#13): shared 昇格後は @ai-rotom/shared の共通実装に差し替える。
- */
-export function filterResultsByLearnset(
-  results: readonly DamageCalcResult[],
-  learnsetMoveIds: ReadonlySet<string>,
-): DamageCalcResult[] {
-  if (learnsetMoveIds.size === 0) return [...results];
-  return results.filter((r) => learnsetMoveIds.has(toDataId(r.move)));
-}
-
-/**
  * attacker vs defender の候補技でダメージを計算する。
  * movesMap に指定があればそれを、無ければ全技で計算する。
  * movesMap 未指定経路では attacker の learnset でフィルタし、覚えない技での過大評価を避ける。
@@ -302,7 +276,7 @@ export function calculateDamageForMatchup(
     return results;
   }
   const allResults = calculator.calculateAllMoves({ attacker, defender });
-  return filterResultsByLearnset(allResults, attackerLearnsetIds);
+  return filterResultsByLearnset(allResults, attackerLearnsetIds, toDataId);
 }
 
 export function registerSelectionAnalysisTool(server: McpServer): void {


### PR DESCRIPTION
## Summary

#17 / PR #41 のフォローアップ。#13 / PR #37 で `filterResultsByLearnset` が shared に昇格し、`getLearnsetMoveIdSet` も data-store に整備されたため、PR #41 時点で `TODO(#13)` として暫定的に残していた `selection-analysis.ts` のローカル実装を正式版に差し替える。

関連 issue:
- https://github.com/nonz250/ai-rotom/issues/17 (PR #41 でマージ済み)
- https://github.com/nonz250/ai-rotom/issues/13 (PR #37 でマージ済み)

これで `find-counters.ts` / `matchup.ts` / `selection-analysis.ts` の 3 ファイル全てが `@ai-rotom/shared` の `filterResultsByLearnset` と `data-store.ts` の `getLearnsetMoveIdSet` を利用する同一パターンに揃う。

## Changes

* \`packages/mcp-server/src/tools/analysis/selection-analysis.ts\` (+3 / -29)
  * ローカル実装の \`getLearnsetMoveIdSet\` / \`filterResultsByLearnset\` (+ \`TODO(#13)\` コメント) を削除
  * \`filterResultsByLearnset\` を \`@ai-rotom/shared\` から import
  * \`getLearnsetMoveIdSet\` を \`../../data-store.js\` から import (\`toDataId\` と同じ行)
  * \`calculateDamageForMatchup\` 内の呼び出しを 3 引数化: \`filterResultsByLearnset(allResults, attackerLearnsetIds, toDataId)\`
  * \`calculateDamageForMatchup\` のシグネチャ・\`myLearnsetIds\` キャッシュ構造は不変 (スコープ外)
* \`packages/mcp-server/src/tools/analysis/selection-analysis.test.ts\` (+13 / -77)
  * import を shared / data-store 経由に差し替え
  * shared / data-store 側で既にテスト済の重複単体テスト (\`getLearnsetMoveIdSet\` 2 件 + \`filterResultsByLearnset\` 3 件) を削除
  * \`calculateDamageForMatchup\` 結合テスト (3 件) と charizard learnset 前提確認 (2 件) は維持

### コミット構成

1. \`refactor(mcp-server): selection-analysis を shared filterResultsByLearnset に統一する\` — コード差し替え + テスト import 差し替え (この時点で 332/332 pass)
2. \`test(mcp-server): selection-analysis の重複単体テストを削除する\` — 重複単体テスト削除 (327/327 pass)

## Checklist

- [x] \`npm test\` 全 pass (29 files / 327 tests)
- [x] \`npx tsc --noEmit\` エラーなし
- [x] \`npm run build\` 成功
- [x] \`find-counters.ts\` / \`matchup.ts\` と同形の import / 呼び出しパターンに統一
- [x] \`calculateDamageForMatchup\` のシグネチャとキャッシュ構造は不変 (スコープ外遵守)
- [x] 純粋 refactor として挙動差異なし (data-store 版の \`new Set(learnset.map(toDataId))\` は現行 learnsets.json が既に toID 形式のため冪等)
- [x] TODO(#13) コメント削除

## その他

- 本 PR は issue を close しない (#17 / #13 は既に close 済みのフォローアップ clean-up のため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)