### PR TITLE
chore(release): bump to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3505,7 +3505,7 @@
     },
     "packages/mcp-server": {
       "name": "@nonz250/ai-rotom",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonz250/ai-rotom",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pokemon Champions battle advisor MCP server",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

0.0.2 以降にマージ済みの分析系 API の破壊的変更と「客観データ特化」への方針転換を minor bump で明示するためのリリース PR。

close なし (release 用)。

関連 issue (マージ済み): #10 / #11 / #12 / #13 / #14 / #15 / #16 / #17 / #18 / #19 / #20 / #21 / #22 / #23 / #24 / #25 / #26 / #27 / #28

## Changes

* `packages/mcp-server/package.json` の `version` を `0.0.2` → `0.1.0`
* `package-lock.json` の workspace version を追随更新

## Release Notes (0.0.2 → 0.1.0)

### Breaking
- `analyze_selection`: 推奨スコアリングを削除し、総合判断を AI に委ねる (#20)
- `find_counters`: スコア・戦略分類・Top N を削除し、客観データ提供に特化 (#22)
- `analyze_party_weakness`: 経験則ベースの `criticalWeaknesses` 判定を削除 (#25)
- `analyze_party_weakness` / `analyze_party_coverage`: 特性・もちもの・タイプ変更系特性を考慮するようになり、同一入力でも出力値が変化 (#26 / #27)

### Added
- `conditions.battleFormat` でダブルバトル対戦に対応 (省略時 `singles` で後方互換) (#21)
- `analyze_party_coverage`: 実在する複合タイプのカバレッジを追加 (#28)
- `analyze_matchup` / `analyze_selection` / `find_counters` の出力に先制技を独立フィールド化 (#15 / #19 / #24)
- `analyze_matchup` / `analyze_selection` / `find_counters` の各技に STAB・タイプ相性倍率を構造化出力 (#14 / #18 / #23)
- `find_counters` の `candidatePool` に具体 build 指定が可能に (#11)
- instructions に計算・分析系ツールでの特性・もちもの指定推奨を追記 (#10 / #12)

### Refactored
- `filterResultsByLearnset` を shared に昇格し、`analyze_matchup` / `analyze_selection` / `find_counters` で統一利用 (#13 / #16 / #17)

### Chore
- tsdown 0.21.9 / typescript 6.0.3 への依存更新 (dependabot #2 / #3)

## Checklist

- [x] `packages/mcp-server/package.json` の version が `0.1.0`
- [x] `package-lock.json` の mcp-server workspace version も `0.1.0` に追随
- [x] `npm test` 全 pass (32 files / 425 tests)
- [x] `npm run build` 成功 (`dist/index.mjs` 1.72 MB)
- [x] `npm pack --dry-run` で tarball 内容確認 (LICENSE / README.md / THIRD_PARTY_LICENSES.md / dist/index.mjs / package.json)
- [x] `npm audit` 脆弱性 0
- [x] semver 判断: 0.x 系かつ破壊的変更あり → minor bump
- [ ] マージ後: `v0.1.0` タグ打ち → GitHub Release 作成で publish workflow をトリガー
- [ ] publish 後: `npx -y @nonz250/ai-rotom@0.1.0` で stdio 起動確認

## その他

- publish 自体は GitHub Release 作成時に `.github/workflows/publish.yml` がトリガーされる想定
- workflow 内で `Verify version matches release tag` が package.json と tag の一致をチェック
- マージ後の具体的なリリース作業はメンテナ判断に委ねる

🤖 Generated with [Claude Code](https://claude.com/claude-code)