### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -106,6 +107,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3271,7 +3273,7 @@
     },
     "packages/mcp-server": {
       "name": "@nonz250/ai-rotom",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonz250/ai-rotom",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Pokemon Champions battle advisor MCP server",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

Release tag `1.0.0` で publish ワークフローが失敗していたため、`packages/mcp-server/package.json` を `1.0.0` に bump する。

failure: https://github.com/nonz250/ai-rotom/actions/runs/24939918189/job/73031799205

エラー内容:
```
Release tag (1.0.0) does not match package.json version (0.1.0)
```

## Changes

* `packages/mcp-server/package.json` の version を `0.1.0` → `1.0.0` に更新
* `package-lock.json` の `packages/mcp-server` workspace entry の version を同期

## Checklist

- [x] `npm test` が通る (511 passed)
- [x] `npm run build` が通る
- [x] `bash scripts/verify-dist-bundle.sh` が通る
- [x] `npm run test:dist` が通る
- [ ] マージ後、`1.0.0` タグで GitHub Release を再作成して publish ワークフローを起動する

## その他

publish ワークフローは `release: published` イベントで起動するため、本 PR をマージしただけでは npm publish は実行されない。マージ後にリリースを再作成する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)