### PR TITLE
[codex] bump ai-rotom to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3273,7 +3273,7 @@
     },
     "packages/mcp-server": {
       "name": "@nonz250/ai-rotom",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonz250/ai-rotom",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pokemon Champions battle advisor MCP server",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

Bump the published @nonz250/ai-rotom workspace package from 1.0.0 to 1.1.0.

Update package-lock.json so the workspace metadata stays in sync.

## Validation

- npx tsc --noEmit -p packages/mcp-server/tsconfig.json
- npm test
- npm run build
- bash scripts/verify-dist-bundle.sh
- npm run test:dist
- npm_config_cache=/private/tmp/ai-rotom-npm-cache bash scripts/pack-and-install-smoke.sh