### PR TITLE
chore(release): bump ai-rotom to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3206,7 +3206,7 @@
     },
     "packages/mcp-server": {
       "name": "@nonz250/ai-rotom",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonz250/ai-rotom",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pokemon Champions battle advisor MCP server",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

`@nonz250/ai-rotom` の patch version を `1.1.0` → `1.1.1` に bump する。

直近の main 反映分（dependabot 群を含む）を patch リリースとして配布するための version bump のみのコミット。

## Changes

* `packages/mcp-server/package.json` の `version` を `1.1.1` に更新
* `package-lock.json` の対応箇所を追従

## Checklist

- [ ] マージ後、GitHub Release `1.1.1` を作成して `publish.yml` を起動する
- [ ] publish 後に `npm view @nonz250/ai-rotom@1.1.1 version` で registry 反映を確認
- [ ] 空ディレクトリで `npx -y @nonz250/ai-rotom@1.1.1` の stdio 起動を確認

## その他

publish は GitHub Release の `published` イベントで `.github/workflows/publish.yml` が npm Trusted Publisher (OIDC) により自動実行する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)