### PR TITLE
fix(party-coverage): moves パラメータで日本語技名を解決できるようにする

### DIFF
--- a/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.test.ts
@@ -108,7 +108,6 @@ describe("analyze_party_coverage logic", () => {
     //   等倍 (1倍): Normal / Water / Psychic / Ice / Dragon / Dark / Fairy / Ghost / Ground / Fighting
     //   抜群 (2倍): Electric / Poison / Rock / Steel / Fire
     const GROUND_ATTACKER = { name: "ガブリアス" };
-    // 現仕様では moves に指定する技は英語名で渡す必要がある（日本語技名対応は別改修）
     const GROUND_MOVE_SET = { ガブリアス: ["Earthquake"] };
 
     it("しきい値定数は等倍（1倍）である仕様", () => {
@@ -184,6 +183,106 @@ describe("analyze_party_coverage logic", () => {
       expect(attacker?.effectiveType).toBeUndefined();
       expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(true);
       expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(false);
+    });
+  });
+
+  describe("moves パラメータの技名解決（日本語・英語両対応）", () => {
+    const SUPER_EFFECTIVE = 2;
+
+    it("日本語技名（じしん）でも attackingTypes に Ground が含まれる", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["じしん"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Ground")).toBe(true);
+      const electric = out.coverage.find((c) => c.defenderType === "Electric");
+      expect(electric?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(electric?.bestAttackers[0].move).toBe("Earthquake");
+    });
+
+    it("日本語名と英語名が混在する moves マップでも動作する", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["じしん", "Hyper Beam"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Ground")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(true);
+    });
+
+    it("Issue #80 再現ケース: 日本語技名で attackingTypes が空にならず正しい攻撃タイプ集合が得られる", () => {
+      // Issue #80 で報告された構築・moves セット。修正前は attackingTypes: [] だった。
+      const out = analyzePartyCoverage({
+        myParty: [
+          { name: "ヒスイダイケンキ", nature: "いじっぱり", ability: "きれあじ", item: "くろいメガネ" },
+          { name: "オオニューラ", nature: "いじっぱり", ability: "かるわざ", item: "しろいハーブ" },
+          { name: "カイリュー", nature: "ひかえめ", ability: "マルチスケイル", item: "カイリュナイト" },
+        ],
+        moves: {
+          ヒスイダイケンキ: ["ひけん・ちえなみ", "シェルブレード", "せいなるつるぎ", "ふいうち"],
+          オオニューラ: ["フェイタルクロー", "インファイト", "ねこだまし", "ちょうはつ"],
+          カイリュー: ["りゅうせいぐん", "かえんほうしゃ", "１０まんボルト", "ぼうふう"],
+        },
+      });
+
+      // 修正前は attackingTypes が空配列だったので、空でないことを最低限保証する
+      expect(out.attackingTypes.length).toBeGreaterThan(0);
+      // 各メンバーの代表的な攻撃タイプが反映されていること
+      // ヒスイダイケンキ: あく (ふいうち) / みず (シェルブレード) / かくとう (せいなるつるぎ) を含む
+      const types = out.attackingTypes.map((t) => t.type);
+      expect(types).toContain("Dark");
+      expect(types).toContain("Water");
+      expect(types).toContain("Fighting");
+      // オオニューラ: どく (フェイタルクロー) など
+      expect(types).toContain("Poison");
+      // カイリュー: ドラゴン / ほのお / でんき / ひこう を含む
+      expect(types).toContain("Dragon");
+      expect(types).toContain("Fire");
+      expect(types).toContain("Electric");
+      expect(types).toContain("Flying");
+
+      // 全タイプの maxMultiplier=0 にはならない（少なくとも 1 タイプ以上は抜群を取れる）
+      const hasAnyEffectiveCoverage = out.coverage.some((c) => c.maxMultiplier > EFFECTIVE_THRESHOLD);
+      expect(hasAnyEffectiveCoverage).toBe(true);
+      // dualTypeUncoveredCount は 93（全エントリ uncovered）ではない
+      expect(out.dualTypeUncoveredCount).toBeLessThan(out.dualTypeCoverage.length);
+    });
+
+    it("日本語技名でも Pixilate のタイプ変換特性が反映される", () => {
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "メガチルタリス", ability: "フェアリースキン" }],
+        moves: { メガチルタリス: ["はかいこうせん"] },
+      });
+
+      expect(out.attackingTypes.some((t) => t.type === "Fairy")).toBe(true);
+      expect(out.attackingTypes.some((t) => t.type === "Normal")).toBe(false);
+
+      const dragon = out.coverage.find((c) => c.defenderType === "Dragon");
+      expect(dragon?.maxMultiplier).toBe(SUPER_EFFECTIVE);
+      expect(dragon?.bestAttackers[0].effectiveType).toBe("Fairy");
+    });
+
+    it("未知の技名はサジェスト付きエラーで throw される（silent skip しない）", () => {
+      expect(() =>
+        analyzePartyCoverage({
+          myParty: [{ name: "ガブリアス" }],
+          moves: { ガブリアス: ["そんなわざない"] },
+        }),
+      ).toThrow(/技「そんなわざない」が見つかりません/);
+    });
+
+    it("日本語の変化技（つるぎのまい）は silent skip される（既存仕様の維持）", () => {
+      const NO_EFFECT = 0;
+      const out = analyzePartyCoverage({
+        myParty: [{ name: "ガブリアス" }],
+        moves: { ガブリアス: ["つるぎのまい"] },
+      });
+      // 変化技のみ指定 → 攻撃技ゼロ扱い
+      expect(out.attackingTypes).toHaveLength(0);
+      for (const entry of out.coverage) {
+        expect(entry.maxMultiplier).toBe(NO_EFFECT);
+      }
     });
   });
 

--- a/packages/mcp-server/src/tools/analysis/party-coverage.ts
+++ b/packages/mcp-server/src/tools/analysis/party-coverage.ts
@@ -22,6 +22,7 @@ import {
 } from "../../data-store.js";
 import {
   abilityNameResolver,
+  moveNameResolver,
   pokemonNameResolver,
 } from "../../name-resolvers.js";
 import { withHint } from "../../tool-response-hint.js";
@@ -136,6 +137,29 @@ export interface PartyCoverageOutput {
 }
 
 /**
+ * 技名を英語名に解決する。日本語名・英語名どちらでも受け付ける。
+ * 未知の名前は類似サジェスト付きでエラーを throw する。
+ *
+ * `resolvePokemonEntry` と同様の方針で、未知名は silent skip せずに
+ * 呼び出し側へエラーとして伝える（silent skip だと「指定 moves が
+ * 0 件 → 全タイプ uncovered」のような不可視バグを引き起こすため）。
+ */
+function resolveMoveEnglishName(name: string): string {
+  const fromJa = moveNameResolver.toEnglish(name);
+  if (fromJa !== undefined) {
+    return fromJa;
+  }
+  if (moveNameResolver.hasEnglishName(name)) {
+    return name;
+  }
+
+  const suggestions = moveNameResolver.suggestSimilar(name);
+  const suggestionMessage =
+    suggestions.length > 0 ? ` もしかして: ${suggestions.join(", ")}` : "";
+  throw new Error(`技「${name}」が見つかりません。${suggestionMessage}`);
+}
+
+/**
  * 1 メンバー分の「覚えている攻撃技 ID」を取得する。
  * moves 指定があればそれを使い、未指定時は learnset から category !== Status の技を全て拾う。
  */
@@ -146,7 +170,8 @@ function resolveAttackingMoveIds(
   if (explicitMoves !== undefined) {
     const result: MoveEntry[] = [];
     for (const moveName of explicitMoves) {
-      const moveId = toDataId(moveName);
+      const englishName = resolveMoveEnglishName(moveName);
+      const moveId = toDataId(englishName);
       const move = movesById.get(moveId);
       if (move !== undefined && move.category !== STATUS_CATEGORY) {
         result.push(move);


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/ai-rotom/issues/80

`analyze_party_coverage` の `moves` パラメータが日本語技名を一切受け付けず、`attackingTypes: []` と全タイプ `maxMultiplier: 0` を返してしまうバグを修正する。

### 原因

`resolveAttackingMoveIds` 内で `toDataId(moveName)` を直接呼んでいた。
`toDataId` は `name.toLowerCase().replace(/[^a-z0-9]/g, "")` という実装で、非 ASCII 文字を全削除する。そのため `"ひけん・ちえなみ"` → `""` のような変換となり、`movesById.get("")` で undefined → silent skip となっていた。

加えて未知技名が silent skip される設計だったため、「指定 moves が全件無効 → 攻撃技ゼロ扱い → 全タイプ uncovered」というバグが結果から見えづらかった。

### 修正方針

`moveNameResolver` を `info/move-info.ts` と同じパターンで導入:

1. `moveNameResolver.toEnglish(moveName)` で日本語→英語へ変換を試行
2. 失敗時は `moveNameResolver.hasEnglishName(moveName)` で英語名既出か確認
3. どちらでも見つからない場合は `suggestSimilar()` 付きでエラー throw（silent skip でバグを隠さない）
4. 解決後の英語名で `toDataId()` → `movesById.get()`

`Status` カテゴリの silent skip はそのまま維持（変化技を渡したケースの既存テスト挙動を保持するため）。

## Changes

* `packages/mcp-server/src/tools/analysis/party-coverage.ts`
  * `moveNameResolver` を import
  * `resolveMoveEnglishName(name)` ヘルパを追加（`info/move-info.ts` の `resolveMoveNameEn` と同形）
  * `resolveAttackingMoveIds` の `explicitMoves` ループで `resolveMoveEnglishName` を経由
* `packages/mcp-server/src/tools/analysis/party-coverage.test.ts`
  * 「日本語技名対応は別改修」コメントを削除
  * 日本語技名 / 日英混在 / Issue #80 再現ケース / Pixilate × 日本語技名 / 未知技名 throw / 日本語変化技 silent skip の 6 テストを追加

## Checklist

- [x] 既存テストが全て通る（537 / 537 pass）
- [x] 追加テストが Issue #80 の再現と修正を検証する（6 新規ケース全 pass）
- [x] ビルドが成功する
- [x] スキーマ互換性を維持（inputSchema は元から「日本語 or 英語」を謳っており description 変更なし）

## その他

`analyze_party_weakness` 等の他ツールには影響なし（このバグは `analyze_party_coverage` 固有）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)