### PR TITLE
chore(release): bump ai-rotom to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2898,7 +2898,7 @@
     },
     "packages/mcp-server": {
       "name": "@nonz250/ai-rotom",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonz250/ai-rotom",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Pokemon Champions battle advisor MCP server",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

`@nonz250/ai-rotom` の patch version を `1.1.1` → `1.1.2` に bump する。

1.1.1 以降に main へ入った不具合修正と依存更新を patch リリースとして配布するための version bump のみのコミット。利用者向けの主な変更は `analyze_party_coverage` の `moves` パラメータで日本語技名を解決できるようにした不具合修正 (#81)。

## Changes

* `packages/mcp-server/package.json` の `version` を `1.1.2` に更新
* `package-lock.json` の対応箇所を追従

### このリリースに含まれる main 反映分

* #81 fix(party-coverage): moves パラメータで日本語技名を解決できるようにする
* #84 chore(deps): bump qs 6.15.1 → 6.15.2
* #82 chore(deps-dev): bump vitest 4.1.5 → 4.1.6
* #79 chore(deps): bump fast-uri 3.1.0 → 3.1.2

## Checklist

- [ ] マージ後、GitHub Release `1.1.2` を作成して `publish.yml` を起動する
- [ ] publish 後に `npm view @nonz250/ai-rotom@1.1.2 version` で registry 反映を確認
- [ ] 空ディレクトリで `npx -y @nonz250/ai-rotom@1.1.2` の stdio 起動を確認

## その他

publish は GitHub Release の `published` イベントで `.github/workflows/publish.yml` が npm Trusted Publisher (OIDC) により自動実行する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
