### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,7 +3229,7 @@
     },
     "packages/mcp-server": {
       "name": "@nonz250/ai-rotom",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonz250/ai-rotom",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Pokemon Champions battle advisor MCP server",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

レギュレーション M-B（シーズン M-3、2026-06-17 開始）で追加されたポケモン・もちもののマスターデータを追加します。あわせて `@smogon/calc` を upstream 最新に更新しています。

## Changes

### @smogon/calc 更新

upstream master HEAD（commit `2e32176`）から再ビルドした tarball に差し替えました。Light Ball の Champions 対応修正等を含みます。

### M-B レギュレーションデータ追加

攻略サイトの公開情報を元に、M-B で新規追加されたポケモン・もちものデータを整備しました。

- 通常ポケモン 22 体 + メガシンカ 16 体 = 計 38 エントリを `pokemon.json` に追加
- 関連する技 31 種を `moves.json` に追加
- 関連する特性 7 種を `abilities.json` に追加
- 22 体分の習得技リストを `learnsets.json` に追加（メガシンカはベースフォルムと共有）
- メガストーン 16 種 + 通常もちもの 15 種 = 計 31 エントリを `items.json` に追加
- 既存 Raichu エントリに `otherFormes`（Mega X / Mega Y）の参照を追加

### ドキュメント更新

`data/champions/CLAUDE.md` の件数目安をデータ追加後の値に更新しました。

## Checklist

- [x] 全テスト通過（537/537）
- [x] ビルド成功
- [x] 相互参照の整合性検証（learnset → moves、pokemon → abilities、items.megaStone ↔ pokemon、baseSpecies ↔ otherFormes）
- [x] dist バンドルに新データが含まれることを確認
- [x] vendor tarball の integrity hash 3 点突合（vendor/README.md、package-lock.json、実ファイル）

## その他

MCP サーバーの実行プロセスが古い dist を使っている場合は再起動が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
