### PR TITLE
chore: bump version to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3284,7 +3284,7 @@
     },
     "packages/mcp-server": {
       "name": "@nonz250/ai-rotom",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonz250/ai-rotom",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Pokemon Champions battle advisor MCP server",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary

パッケージバージョンを 1.2.2 → 1.2.3 に更新します。

## Changes

* `packages/mcp-server/package.json` の version を 1.2.3 に更新

## Checklist

- [ ] `npm run build` が通ること
- [ ] `npm test` が通ること
- [ ] publish 後に `npx @nonz250/ai-rotom@1.2.3` で起動確認

## その他

🤖 Generated with [Claude Code](https://claude.com/claude-code)
